### PR TITLE
Updated dependencies to be compatible with yesod

### DIFF
--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -1,6 +1,6 @@
 Name:                hoauth2
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy)
-Version:             0.2.6.1
+Version:             0.3.0
 
 Synopsis:            hoauth2
 Description:


### PR DESCRIPTION
I couldn't use this project with the latest yesod, so I looked at the latest version ranges of dependencies in common with the yesod platform and updated them. Everything compiles!

Based on yesod-platform 1.1.8
