### PR TITLE
Lower bounds on Data.Text

### DIFF
--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -55,7 +55,7 @@ Library
   Build-Depends:
     aeson             >= 0.7    && < 0.8,
     base              >= 4      && < 5,
-    text              >= 1.1    && < 1.2,
+    text              >= 0.11   && < 1.2,
     bytestring        >= 0.9    && < 0.11,
     bytestring-show   >= 0.3.5  && < 0.4,
     conduit           >= 1.0    && < 1.1,


### PR DESCRIPTION
I needed this to use hoauth2 on a project with Text 0.11 -- seems to work fine.
