### PR TITLE
Revert bytestring bounds

### DIFF
--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -60,7 +60,7 @@ Library
     base              >= 4      && < 5,
     aeson             >= 0.7    && < 0.9,
     text              >= 0.11   && < 1.3,
-    bytestring        >= 0.10.4 && < 0.10.5,
+    bytestring        >= 0.9    && < 0.11,
     http-conduit      >= 2.0    && < 2.2,
     http-types        >= 0.8    && < 0.9
 


### PR DESCRIPTION
The version constraint was tightened in d0af94fb; it's unclear why.

My install of 7.10.1 (Arch Linux) updates the global bytestring to 0.10.6.
Downgrading leads to cascading issues when I attempt to build
yesod-auth-oauth2. Not knowing the motivation for the original change, I
decided to revert back to what it was before, rather than only allowing 0.10.6
and possibly running into this again later.