### PR TITLE
Add support for access token api that returns string

### DIFF
--- a/example/StackExchange/test.hs
+++ b/example/StackExchange/test.hs
@@ -1,41 +1,41 @@
-{-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 -- | Github API: http://developer.github.com/v3/oauth/
 
 module Main where
 
-import           Data.Aeson.TH                 (defaultOptions, deriveJSON)
-import qualified Data.ByteString.Char8      as BS
-import           Data.Text            (Text)
-import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as T
+import           Data.Aeson.TH         (defaultOptions, deriveJSON)
+import qualified Data.ByteString.Char8 as BS
+import           Data.Text             (Text)
+import qualified Data.Text             as T
+import qualified Data.Text.Encoding    as T
 import           Network.HTTP.Conduit
 
 import           Network.OAuth.OAuth2
 
 import           Keys
 
-data SiteInfo = SiteInfo { items   :: [SiteItem]
-                         , has_more :: Bool
-                         , quota_max :: Integer
+data SiteInfo = SiteInfo { items           :: [SiteItem]
+                         , has_more        :: Bool
+                         , quota_max       :: Integer
                          , quota_remaining :: Integer
                          } deriving (Show, Eq)
 
-data SiteItem = SiteItem { new_active_users :: Integer
-                           , total_users :: Integer
-                           , badges_per_minute :: Double
-                           , total_badges :: Integer
-                           , total_votes :: Integer
-                           , total_comments :: Integer
-                           , answers_per_minute :: Double
+data SiteItem = SiteItem { new_active_users       :: Integer
+                           , total_users          :: Integer
+                           , badges_per_minute    :: Double
+                           , total_badges         :: Integer
+                           , total_votes          :: Integer
+                           , total_comments       :: Integer
+                           , answers_per_minute   :: Double
                            , questions_per_minute :: Double
-                           , total_answers :: Integer
-                           , total_accepted :: Integer
-                           , total_unanswered :: Integer
-                           , total_questions :: Integer
-                           , api_revision :: Text
+                           , total_answers        :: Integer
+                           , total_accepted       :: Integer
+                           , total_unanswered     :: Integer
+                           , total_questions      :: Integer
+                           , api_revision         :: Text
                          } deriving (Show, Eq)
 
 $(deriveJSON defaultOptions ''SiteInfo)

--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -1,6 +1,6 @@
 Name:                hoauth2
 -- http://wiki.haskell.org/Package_versioning_policy
-Version:             0.5.4.0
+Version:             0.5.5.0
 
 Synopsis:            Haskell OAuth2 authentication client
 Description:

--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -58,12 +58,13 @@ Library
     Network.OAuth.OAuth2
 
   Build-Depends:
-    base              >= 4     && < 5,
-    aeson             >= 0.9   && < 0.12,
-    text              >= 0.11  && < 1.3,
-    bytestring        >= 0.9   && < 0.11,
-    http-conduit      >= 2.0   && < 2.2,
-    http-types        >= 0.9   && < 0.10
+    base                 >= 4     && < 5,
+    aeson                >= 0.9   && < 0.12,
+    text                 >= 0.11  && < 1.3,
+    bytestring           >= 0.9   && < 0.11,
+    http-conduit         >= 2.0   && < 2.2,
+    http-types           >= 0.9   && < 0.10,
+    unordered-containers >=0.2.5
 
   if impl(ghc >= 6.12.0)
       ghc-options: -Wall -fwarn-tabs -funbox-strict-fields

--- a/src/Network/OAuth/OAuth2/HttpClient.hs
+++ b/src/Network/OAuth/OAuth2/HttpClient.hs
@@ -174,11 +174,11 @@ parseResponseJSON (Right b) = case decode b of
                             Just x -> Right x
 
 -- | Parses a @OAuth2Result BSL.ByteString@ that contains not JSON but a Query String
-parseResponseUrl :: FromJSON a
+parseResponseString :: FromJSON a
               => OAuth2Result BSL.ByteString
               -> OAuth2Result a
-parseResponseUrl (Left b) = Left b
-parseResponseUrl (Right b) = case parseQuery $ BSL.toStrict b of
+parseResponseString (Left b) = Left b
+parseResponseString (Right b) = case parseQuery $ BSL.toStrict b of
                               [] -> Left errorMessage
                               a -> case fromJSON $ queryToValue a of
                                     Error _ -> Left errorMessage
@@ -188,12 +188,12 @@ parseResponseUrl (Right b) = case parseQuery $ BSL.toStrict b of
     paramToPair (k, mv) = (T.decodeUtf8 k, maybe Null (String . T.decodeUtf8) mv)
     errorMessage = ("hoauth2.HttpClient.parseResponseJSON/Could not decode JSON or URL: " `BSL.append` b)
 
--- | Try 'parseResponseJSON' and 'parseResponseUrl'
+-- | Try 'parseResponseJSON' and 'parseResponseString'
 parseResponseFlexible :: FromJSON a
                          => OAuth2Result BSL.ByteString
                          -> OAuth2Result a
 parseResponseFlexible r = case parseResponseJSON r of
-                           Left _ -> parseResponseUrl r
+                           Left _ -> parseResponseString r
                            x -> x
 
 -- | Set several header values:

--- a/src/Network/OAuth/OAuth2/HttpClient.hs
+++ b/src/Network/OAuth/OAuth2/HttpClient.hs
@@ -29,12 +29,12 @@ import           Control.Monad                 (liftM)
 import           Data.Aeson
 import qualified Data.ByteString.Char8         as BS
 import qualified Data.ByteString.Lazy.Char8    as BSL
+import qualified Data.HashMap.Strict           as HM (fromList)
 import           Data.Maybe
+import qualified Data.Text.Encoding            as T
 import           Network.HTTP.Conduit          hiding (withManager)
 import qualified Network.HTTP.Types            as HT
-import qualified Data.Text.Encoding as T
-import Network.HTTP.Types.URI (parseQuery)
-import qualified Data.HashMap.Strict as HM (fromList)
+import           Network.HTTP.Types.URI        (parseQuery)
 import           Network.OAuth.OAuth2.Internal
 
 --------------------------------------------------


### PR DESCRIPTION
Add support for access token api that returns string.
related issue is #47 .

I added `parseResponseFlexible`.
It will try to parse response as query string when it failed to parse as json.

--
BTW, In #47 , I solved problem by using `doSimplePostRequest`.
However, because I want to do the same via [yesod-auth-oauth2](https://github.com/thoughtbot/yesod-auth-oauth2), I want to solve in `fetchAccessToken`.