### PR TITLE
In the case of a JSON decode error, don't decode as a OAuth2Error

### DIFF
--- a/src/Network/OAuth/OAuth2/HttpClient.hs
+++ b/src/Network/OAuth/OAuth2/HttpClient.hs
@@ -185,9 +185,9 @@ parseResponseJSON :: FromJSON err => FromJSON a
               => OAuth2Result err BSL.ByteString
               -> OAuth2Result err a
 parseResponseJSON (Left b) = Left b
-parseResponseJSON (Right b) = case decode b of
-                            Nothing -> Left (parseOAuth2Error b)
-                            Just x -> Right x
+parseResponseJSON (Right b) = case eitherDecode b of
+                            Left e -> Left $ mkDecodeOAuth2Error b e
+                            Right x -> Right x
 
 -- | Parses a @OAuth2Result BSL.ByteString@ that contains not JSON but a Query String
 parseResponseString :: FromJSON err => FromJSON a

--- a/src/Network/OAuth/OAuth2/Internal.hs
+++ b/src/Network/OAuth/OAuth2/Internal.hs
@@ -88,8 +88,14 @@ instance ToJSON err => ToJSON (OAuth2Error err) where
 
 parseOAuth2Error :: FromJSON err => BSL.ByteString -> OAuth2Error err
 parseOAuth2Error string =
-  either (\err -> OAuth2Error (Left "Decode error") (Just $ pack $ "Error: " <> err <> "\n Original Response:\n" <> show (decodeUtf8 $ BSL.toStrict string)) Nothing) id (eitherDecode string)
+  either (mkDecodeOAuth2Error string) id (eitherDecode string)
 
+mkDecodeOAuth2Error :: BSL.ByteString -> String -> OAuth2Error err
+mkDecodeOAuth2Error response err =
+  OAuth2Error
+    (Left "Decode error")
+    (Just $ pack $ "Error: " <> err <> "\n Original Response:\n" <> show (decodeUtf8 $ BSL.toStrict response))
+    Nothing
 
 --------------------------------------------------
 -- * Types Synonym


### PR DESCRIPTION
If the response failed to decode with `decode`, then `parseOAuth2Error` would try and decode the response as a `OAuth2Error`.  This would always fail because the response is not a `OAuth2Error`, and it would fail with an error saying that the key `error` does not exist.

I've updated this so that `parseResponseJSON` now calls `eitherDecode` directly, and returns the error from the initial decode.

I did it this way because the code is nicer. If the reason you were calling `decode` first, and then only calling `eitherDecode` in the case of an error was for performance reasons, then I can try changing this around a bit to maintain that.