### PR TITLE
Build with stack lts-12.9 (GHC 8.4.3)

### DIFF
--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -72,17 +72,17 @@ Library
                    Network.OAuth.OAuth2.TokenRequest
                    Network.OAuth.OAuth2.AuthorizationRequest
 
-  Build-Depends: base                 >= 4     && < 5,
-                 text                 >= 0.11  && < 1.3,
-                 bytestring           >= 0.9   && < 0.11,
-                 http-conduit         >= 2.1   && < 2.4,
-                 http-types           >= 0.11   && < 0.13,
-                 aeson                >= 0.11  && < 1.4,
-                 unordered-containers >= 0.2.5,
-                 uri-bytestring       >= 0.2.3.1 && < 0.4,
-                 uri-bytestring-aeson >= 0.1   && < 0.2,
-                 microlens            >= 0.4.0 && < 0.5,
-                 exceptions           >= 0.8.3 && < 0.11
+  Build-Depends: base >= 4.7 && < 5,
+                 text,
+                 bytestring,
+                 http-conduit,
+                 http-types,
+                 aeson,
+                 unordered-containers,
+                 uri-bytestring,
+                 uri-bytestring-aeson,
+                 microlens,
+                 exceptions
 
   if impl(ghc >= 6.12.0)
       ghc-options: -Wall -fwarn-tabs -funbox-strict-fields
@@ -116,26 +116,26 @@ Executable demo-server
                        Views
   hs-source-dirs:      example
   default-language:    Haskell2010
-  build-depends:       base              >= 4.5    && < 5,
-                       text              >= 0.11   && < 1.3,
-                       bytestring        >= 0.9    && < 0.11,
-                       uri-bytestring    >= 0.2.3.1 && < 0.4,
-                       http-conduit      >= 2.1    && < 2.4,
-                       http-types        >= 0.11    && < 0.13,
-                       wai               >= 3.2    && < 3.3,
-                       warp              >= 3.2    && < 3.3,
-                       containers        >= 0.4    && < 0.6,
-                       aeson             >= 0.11   && < 1.4,
-                       microlens            >= 0.4.0 && < 0.5,
-                       unordered-containers >= 0.2.8 && < 0.2.9,
-                       wai-extra >= 3.0.21.0 && < 3.0.22.0,
-                       wai-middleware-static == 0.8.1,
-                       mustache >= 2.2.3 && < 2.3.0,
-                       mtl >= 2.2.1 && < 2.3,
-                       scotty == 0.10.0,
-                       binary >= 0.8.3.0 && < 0.8.5,
-                       parsec >= 3.1.11 && < 3.2.0 ,
-                       hashable >= 1.2.6 && < 1.3.0,
+  build-depends:       base >= 4.7 && < 5,
+                       text,
+                       bytestring,
+                       uri-bytestring,
+                       http-conduit,
+                       http-types,
+                       wai,
+                       warp,
+                       containers,
+                       aeson,
+                       microlens,
+                       unordered-containers,
+                       wai-extra,
+                       wai-middleware-static,
+                       mustache,
+                       mtl,
+                       scotty,
+                       binary,
+                       parsec,
+                       hashable,
                        hoauth2
 
   if impl(ghc >= 6.12.0)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-9.21
+resolver: lts-12.9
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,8 +9,9 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - http-types-0.12
-  - http-conduit-2.3.0
+  - http-types-0.12.1
+  - http-conduit-2.3.2
+  - uri-bytestring-aeson-0.1.0.6
 
 allow-newer: true
 


### PR DESCRIPTION
For reference, build on GHC 8.4.3, leveraging lts-12.9 for most of the packages.