### PR TITLE
fix missing imports for ghc 8.6.4

### DIFF
--- a/src/Network/OAuth/OAuth2/AuthorizationRequest.hs
+++ b/src/Network/OAuth/OAuth2/AuthorizationRequest.hs
@@ -3,6 +3,8 @@
 module Network.OAuth.OAuth2.AuthorizationRequest where
 
 import           Data.Aeson
+import           Data.Aeson.Types (allNullaryToStringTag, camelTo2,
+                                   constructorTagModifier)
 import           GHC.Generics
 
 instance FromJSON Errors where

--- a/src/Network/OAuth/OAuth2/Internal.hs
+++ b/src/Network/OAuth/OAuth2/Internal.hs
@@ -14,7 +14,10 @@ import           Control.Applicative
 import           Control.Arrow        (second)
 import           Control.Monad.Catch
 import           Data.Aeson
-import           Data.Aeson.Types (explicitParseFieldMaybe, Parser)
+import           Data.Aeson.Types     (Parser, allNullaryToStringTag, camelTo2,
+                                       constructorTagModifier,
+                                       explicitParseFieldMaybe,
+                                       fieldLabelModifier)
 import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Maybe
@@ -62,7 +65,7 @@ data OAuth2Token = OAuth2Token {
 
 parseIntFlexible :: Value -> Parser Int
 parseIntFlexible (String s) = pure . read $ unpack s
-parseIntFlexible v = parseJSON v
+parseIntFlexible v          = parseJSON v
 
 -- | Parse JSON data into 'OAuth2Token'
 instance FromJSON OAuth2Token where

--- a/src/Network/OAuth/OAuth2/TokenRequest.hs
+++ b/src/Network/OAuth/OAuth2/TokenRequest.hs
@@ -3,6 +3,8 @@
 module Network.OAuth.OAuth2.TokenRequest where
 
 import           Data.Aeson
+import           Data.Aeson.Types (allNullaryToStringTag, camelTo2,
+                                   constructorTagModifier)
 import           GHC.Generics
 
 instance FromJSON Errors where


### PR DESCRIPTION
With ghc 8.6.4 hoauth2 would not build on my laptop due to missing imports.
This is a quick fix to get it building for me.
I hope this is useful, I did not dig in to see if there's a different root problem!