### PR TITLE
Add `Binary OAuth2Token` instance

### DIFF
--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -76,6 +76,7 @@ Library
                    Network.OAuth.OAuth2.AuthorizationRequest
 
   Build-Depends: base                 >= 4     && < 5,
+                 binary               >= 0.8.3.0 && < 0.8.7,
                  text                 >= 0.11  && < 1.3,
                  bytestring           >= 0.9   && < 0.11,
                  http-conduit         >= 2.1   && < 2.4,

--- a/src/Network/OAuth/OAuth2/Internal.hs
+++ b/src/Network/OAuth/OAuth2/Internal.hs
@@ -15,6 +15,7 @@ import           Control.Arrow        (second)
 import           Control.Monad.Catch
 import           Data.Aeson
 import           Data.Aeson.Types     (Parser, explicitParseFieldMaybe)
+import           Data.Binary          (Binary)
 import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Maybe
@@ -42,9 +43,9 @@ data OAuth2 = OAuth2 {
     , oauthCallback            :: Maybe URI
     } deriving (Show, Eq)
 
-newtype AccessToken = AccessToken { atoken :: Text } deriving (Show, FromJSON, ToJSON)
-newtype RefreshToken = RefreshToken { rtoken :: Text } deriving (Show, FromJSON, ToJSON)
-newtype IdToken = IdToken { idtoken :: Text } deriving (Show, FromJSON, ToJSON)
+newtype AccessToken = AccessToken { atoken :: Text } deriving (Binary, Show, FromJSON, ToJSON)
+newtype RefreshToken = RefreshToken { rtoken :: Text } deriving (Binary, Show, FromJSON, ToJSON)
+newtype IdToken = IdToken { idtoken :: Text } deriving (Binary, Show, FromJSON, ToJSON)
 newtype ExchangeToken = ExchangeToken { extoken :: Text } deriving (Show, FromJSON, ToJSON)
 
 
@@ -59,6 +60,8 @@ data OAuth2Token = OAuth2Token {
     , tokenType    :: Maybe Text
     , idToken      :: Maybe IdToken
     } deriving (Show, Generic)
+
+instance Binary OAuth2Token
 
 parseIntFlexible :: Value -> Parser Int
 parseIntFlexible (String s) = pure . read $ unpack s


### PR DESCRIPTION
Hi there! Thank you for maintaining a great OAuth2 implementation, much appreciated!

I recently submitted a PR to the `wai-middleware-auth` package, which uses this library. In it I'm trying to store a serialized copy of an `OAuth2Token` in a cookie. Ideally I'd like to use a `Binary` encoding for that, which requires a couple of `Binary` instances on `OAuth2Token` and it's constituent types. I was wondering if you were open to that.

I realize there's a downside to that: the library doesn't currently seem to have a dependency on the `binary` package. If you don't want to change that I understand, no hard feelings, but I thought I'd give it a shot :).

Reference to the other PR:
https://github.com/fpco/wai-middleware-auth/pull/7