### PR TITLE
Lifts restrictive upper bound (mustache < 2.4.0)

### DIFF
--- a/hoauth2.cabal
+++ b/hoauth2.cabal
@@ -135,7 +135,7 @@ Executable demo-server
                        microlens            >= 0.4.0 && < 0.5,
                        unordered-containers >= 0.2.5,
                        wai-middleware-static >= 0.8.1 && < 0.10.0,
-                       mustache >= 2.2.3 && < 2.4.0,
+                       mustache >= 2.2.3 && < 2.5.0,
                        scotty >= 0.10.0 && < 0.13,
                        binary >= 0.8.3.0 && < 0.8.9,
                        parsec >= 3.1.11 && < 3.2.0 ,


### PR DESCRIPTION
Resolves https://github.com/commercialhaskell/stackage/issues/6421.

EDIT: Haven't tested this locally; just made the change and figured I'd let CI run.