### PR TITLE
Refactor http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Travis Status](https://app.travis-ci.com/freizl/hoauth2.svg?branch=master)](http://app.travis-ci.com/github/freizl/hoauth2)
 [![Hackage](https://img.shields.io/hackage/v/hoauth2.svg)](https://hackage.haskell.org/package/hoauth2)
 
-* Introduction
+## Introduction
 
 A mixed Haskell binding of [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc6749) and a little bit [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html).
 
 
-* Contribute
+## Contribute
 
 Feel free send pull request or submit issue ticket.

--- a/hoauth2-example/src/IDP/Douban.hs
+++ b/hoauth2-example/src/IDP/Douban.hs
@@ -23,11 +23,11 @@ instance IDP Douban
 instance HasLabel Douban where
   idpLabel = const "Douban"
 
-instance HasTokenRefreshReq Douban where
-  tokenRefreshReq (Douban key) mgr = refreshAccessToken mgr key
-
 instance HasTokenReq Douban where
-  tokenReq (Douban key) mgr = fetchAccessToken2 mgr key
+  tokenReq (Douban key) mgr = fetchAccessTokenClientCredInBoth mgr key
+
+instance HasTokenRefreshReq Douban where
+  tokenRefreshReq (Douban key) mgr = refreshAccessTokenClientCredInBoth mgr key
 
 instance HasUserReq Douban where
   userReq _ mgr at = do

--- a/hoauth2-example/src/IDP/Douban.hs
+++ b/hoauth2-example/src/IDP/Douban.hs
@@ -24,10 +24,10 @@ instance HasLabel Douban where
   idpLabel = const "Douban"
 
 instance HasTokenReq Douban where
-  tokenReq (Douban key) mgr = fetchAccessTokenClientCredInBoth mgr key
+  tokenReq (Douban key) mgr = fetchAccessTokenInternal ClientSecretPost mgr key
 
 instance HasTokenRefreshReq Douban where
-  tokenRefreshReq (Douban key) mgr = refreshAccessTokenClientCredInBoth mgr key
+  tokenRefreshReq (Douban key) mgr = refreshAccessTokenInternal ClientSecretPost mgr key
 
 instance HasUserReq Douban where
   userReq _ mgr at = do

--- a/hoauth2-example/src/IDP/Dropbox.hs
+++ b/hoauth2-example/src/IDP/Dropbox.hs
@@ -33,7 +33,7 @@ instance HasTokenRefreshReq Dropbox where
 
 instance HasUserReq Dropbox where
   userReq _ mgr at = do
-    re <- authPostBS3 mgr at userInfoUri
+    re <- authPostBS mgr at userInfoUri
     case eitherDecode re of
       Right obj -> return (toLoginUser obj)
       Left e -> throwE (BSL.pack e)

--- a/hoauth2-example/src/IDP/Dropbox.hs
+++ b/hoauth2-example/src/IDP/Dropbox.hs
@@ -33,7 +33,7 @@ instance HasTokenRefreshReq Dropbox where
 
 instance HasUserReq Dropbox where
   userReq _ mgr at = do
-    re <- authPostBS mgr at userInfoUri
+    re <- authPostBS mgr at userInfoUri []
     case eitherDecode re of
       Right obj -> return (toLoginUser obj)
       Left e -> throwE (BSL.pack e)

--- a/hoauth2-example/src/IDP/Facebook.hs
+++ b/hoauth2-example/src/IDP/Facebook.hs
@@ -23,10 +23,10 @@ instance HasLabel Facebook where
   idpLabel = const "Facebook"
 
 instance HasTokenReq Facebook where
-  tokenReq (Facebook key) mgr = fetchAccessToken2 mgr key
+  tokenReq (Facebook key) mgr = fetchAccessTokenClientCredInBoth mgr key
 
 instance HasTokenRefreshReq Facebook where
-  tokenRefreshReq (Facebook key) mgr = refreshAccessToken mgr key
+  tokenRefreshReq (Facebook key) mgr = refreshAccessTokenClientCredInBoth mgr key
 
 instance HasUserReq Facebook where
   userReq _ mgr at = do

--- a/hoauth2-example/src/IDP/Facebook.hs
+++ b/hoauth2-example/src/IDP/Facebook.hs
@@ -23,10 +23,10 @@ instance HasLabel Facebook where
   idpLabel = const "Facebook"
 
 instance HasTokenReq Facebook where
-  tokenReq (Facebook key) mgr = fetchAccessTokenClientCredInBoth mgr key
+  tokenReq (Facebook key) mgr = fetchAccessTokenInternal ClientSecretPost mgr key
 
 instance HasTokenRefreshReq Facebook where
-  tokenRefreshReq (Facebook key) mgr = refreshAccessTokenClientCredInBoth mgr key
+  tokenRefreshReq (Facebook key) mgr = refreshAccessTokenInternal ClientSecretPost mgr key
 
 instance HasUserReq Facebook where
   userReq _ mgr at = do

--- a/hoauth2-example/src/IDP/Google.hs
+++ b/hoauth2-example/src/IDP/Google.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module IDP.Google where
-import           Data.Aeson
-import           Data.Hashable
-import           Data.Text.Lazy       (Text)
-import           GHC.Generics
-import           Network.OAuth.OAuth2
-import           Types
-import           URI.ByteString
-import           URI.ByteString.QQ
-import           Utils
+
+import Data.Aeson
+import Data.Hashable
+import Data.Text.Lazy (Text)
+import GHC.Generics
+import Network.OAuth.OAuth2
+import Types
+import URI.ByteString
+import URI.ByteString.QQ
+import Utils
 
 newtype Google = Google OAuth2 deriving (Show, Generic, Eq)
 
@@ -34,20 +35,24 @@ instance HasUserReq Google where
     return (toLoginUser re)
 
 instance HasAuthUri Google where
-  authUri (Google key) = createCodeUri key [ ("state", "Google.test-state-123")
-                                      , ("scope", "https://www.googleapis.com/auth/userinfo.email")
-                                        ]
+  authUri (Google key) =
+    createCodeUri
+      key
+      [ ("state", "Google.test-state-123"),
+        ("scope", "https://www.googleapis.com/auth/userinfo.email")
+      ]
 
-data GoogleUser = GoogleUser { name :: Text
-                             , id   :: Text
-                             } deriving (Show, Generic)
+data GoogleUser = GoogleUser
+  { name :: Text,
+    id :: Text
+  }
+  deriving (Show, Generic)
 
 instance FromJSON GoogleUser where
-    parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+  parseJSON = genericParseJSON defaultOptions {fieldLabelModifier = camelTo2 '_'}
 
 userInfoUri :: URI
 userInfoUri = [uri|https://www.googleapis.com/oauth2/v2/userinfo|]
 
 toLoginUser :: GoogleUser -> LoginUser
-toLoginUser guser = LoginUser { loginUserName = name guser }
-
+toLoginUser guser = LoginUser {loginUserName = name guser}

--- a/hoauth2-example/src/IDP/Okta.hs
+++ b/hoauth2-example/src/IDP/Okta.hs
@@ -19,6 +19,7 @@ newtype Okta = Okta OAuth2
 
 userInfoUri :: URI
 userInfoUri = [uri|https://hw2.trexcloud.com/oauth2/v1/userinfo|]
+
 -- userInfoUri = [uri|https://dev-148986.oktapreview.com/oauth2/v1/userinfo|]
 
 instance Hashable Okta
@@ -42,7 +43,6 @@ instance HasUserReq Okta where
 -- | https://developer.okta.com/docs/reference/api/oidc/#request-parameters
 -- Okta Org AS doesn't support consent
 -- Okta Custom AS does support consent via config (what scope shall prompt consent)
---
 instance HasAuthUri Okta where
   authUri (Okta key) =
     createCodeUri

--- a/hoauth2-example/src/IDP/StackExchange.hs
+++ b/hoauth2-example/src/IDP/StackExchange.hs
@@ -38,10 +38,10 @@ instance HasLabel StackExchange where
   idpLabel = const "StackExchange"
 
 instance HasTokenReq StackExchange where
-  tokenReq (StackExchange key _) mgr = fetchAccessToken2 mgr key
+  tokenReq (StackExchange key _) mgr = fetchAccessTokenClientCredInBoth mgr key
 
 instance HasTokenRefreshReq StackExchange where
-  tokenRefreshReq (StackExchange key _) mgr = refreshAccessToken mgr key
+  tokenRefreshReq (StackExchange key _) mgr = refreshAccessTokenClientCredInBoth mgr key
 
 instance HasUserReq StackExchange where
   userReq (StackExchange _ appKey) mgr token = do

--- a/hoauth2-example/src/IDP/StackExchange.hs
+++ b/hoauth2-example/src/IDP/StackExchange.hs
@@ -45,7 +45,7 @@ instance HasTokenRefreshReq StackExchange where
 
 instance HasUserReq StackExchange where
   userReq (StackExchange _ appKey) mgr token = do
-    re <- authGetBS2 mgr token
+    re <- authGetBS [AuthInRequestQuery] mgr token
               (userInfoUri `appendStackExchangeAppKey` appKey)
     case eitherDecode re of
       Right obj -> return (toLoginUser obj)

--- a/hoauth2-example/src/IDP/StackExchange.hs
+++ b/hoauth2-example/src/IDP/StackExchange.hs
@@ -38,14 +38,14 @@ instance HasLabel StackExchange where
   idpLabel = const "StackExchange"
 
 instance HasTokenReq StackExchange where
-  tokenReq (StackExchange key _) mgr = fetchAccessTokenClientCredInBoth mgr key
+  tokenReq (StackExchange key _) mgr = fetchAccessTokenInternal ClientSecretPost mgr key
 
 instance HasTokenRefreshReq StackExchange where
-  tokenRefreshReq (StackExchange key _) mgr = refreshAccessTokenClientCredInBoth mgr key
+  tokenRefreshReq (StackExchange key _) mgr = refreshAccessTokenInternal ClientSecretPost mgr key
 
 instance HasUserReq StackExchange where
   userReq (StackExchange _ appKey) mgr token = do
-    re <- authGetBS [AuthInRequestQuery] mgr token
+    re <- authGetBSInternal [AuthInRequestQuery] mgr token
               (userInfoUri `appendStackExchangeAppKey` appKey)
     case eitherDecode re of
       Right obj -> return (toLoginUser obj)

--- a/hoauth2-example/src/IDP/Weibo.hs
+++ b/hoauth2-example/src/IDP/Weibo.hs
@@ -37,7 +37,7 @@ instance HasTokenReq Weibo where
 -- access token in query param only
 instance HasUserReq Weibo where
   userReq _ mgr at = do
-    re <- authGetBS2 mgr at userInfoUri
+    re <- authGetBS [AuthInRequestQuery] mgr at userInfoUri
     case eitherDecode re of
       Right obj -> return (toLoginUser obj)
       Left e -> throwE (BSL.pack e)

--- a/hoauth2-example/src/IDP/Weibo.hs
+++ b/hoauth2-example/src/IDP/Weibo.hs
@@ -37,7 +37,7 @@ instance HasTokenReq Weibo where
 -- access token in query param only
 instance HasUserReq Weibo where
   userReq _ mgr at = do
-    re <- authGetBS [AuthInRequestQuery] mgr at userInfoUri
+    re <- authGetBSInternal [AuthInRequestQuery] mgr at userInfoUri
     case eitherDecode re of
       Right obj -> return (toLoginUser obj)
       Left e -> throwE (BSL.pack e)

--- a/hoauth2-example/src/IDP/ZOHO.hs
+++ b/hoauth2-example/src/IDP/ZOHO.hs
@@ -30,10 +30,10 @@ instance HasLabel ZOHO where
   idpLabel = const "ZOHO"
 
 instance HasTokenReq ZOHO where
-  tokenReq (ZOHO key) mgr = fetchAccessToken2 mgr key
+  tokenReq (ZOHO key) mgr = fetchAccessTokenClientCredInBoth mgr key
 
 instance HasTokenRefreshReq ZOHO where
-  tokenRefreshReq (ZOHO key) mgr = refreshAccessToken2 mgr key
+  tokenRefreshReq (ZOHO key) mgr = refreshAccessTokenClientCredInBoth mgr key
 
 instance HasUserReq ZOHO where
   userReq _ mgr at = do

--- a/hoauth2-example/src/IDP/ZOHO.hs
+++ b/hoauth2-example/src/IDP/ZOHO.hs
@@ -30,10 +30,10 @@ instance HasLabel ZOHO where
   idpLabel = const "ZOHO"
 
 instance HasTokenReq ZOHO where
-  tokenReq (ZOHO key) mgr = fetchAccessTokenClientCredInBoth mgr key
+  tokenReq (ZOHO key) mgr = fetchAccessTokenInternal ClientSecretPost mgr key
 
 instance HasTokenRefreshReq ZOHO where
-  tokenRefreshReq (ZOHO key) mgr = refreshAccessTokenClientCredInBoth mgr key
+  tokenRefreshReq (ZOHO key) mgr = refreshAccessTokenInternal ClientSecretPost mgr key
 
 instance HasUserReq ZOHO where
   userReq _ mgr at = do

--- a/hoauth2/src/Network/OAuth/OAuth2.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2.hs
@@ -1,21 +1,30 @@
 ------------------------------------------------------------
+
+------------------------------------------------------------
+
 -- |
 -- Module      :  Network.OAuth.OAuth2
 -- Description :  OAuth2 client
 -- Copyright   :  (c) 2012 Haisheng Wu
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Haisheng Wu <freizl@gmail.com>
--- Stability   :  alpha
+-- Stability   :  Beta
 -- Portability :  portable
 --
 -- A lightweight oauth2 haskell binding.
-------------------------------------------------------------
-
 module Network.OAuth.OAuth2
-       (module Network.OAuth.OAuth2.HttpClient,
-        module Network.OAuth.OAuth2.Internal
-       )
-       where
+  ( module Network.OAuth.OAuth2.HttpClient,
+    module Network.OAuth.OAuth2.AuthorizationRequest,
+    module Network.OAuth.OAuth2.TokenRequest,
+    module Network.OAuth.OAuth2.Internal,
+  )
+where
 
-import           Network.OAuth.OAuth2.HttpClient
-import           Network.OAuth.OAuth2.Internal
+{-
+  Hiding Errors data type from default.
+  Shall qualified import given the naming conflicts.
+-}
+import Network.OAuth.OAuth2.AuthorizationRequest hiding (Errors(..))
+import Network.OAuth.OAuth2.HttpClient
+import Network.OAuth.OAuth2.Internal
+import Network.OAuth.OAuth2.TokenRequest hiding (Errors(..))

--- a/hoauth2/src/Network/OAuth/OAuth2/AuthorizationRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/AuthorizationRequest.hs
@@ -1,19 +1,33 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 module Network.OAuth.OAuth2.AuthorizationRequest where
 
-import           Data.Aeson
-import           GHC.Generics
+import Data.Aeson
+import Data.Maybe
+import qualified Data.Text.Encoding as T
+import GHC.Generics
+import Lens.Micro
+import Network.OAuth.OAuth2.Internal
+import URI.ByteString
+
+--------------------------------------------------
+
+-- * Errors
+
+--------------------------------------------------
 
 instance FromJSON Errors where
-  parseJSON = genericParseJSON defaultOptions { constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True }
+  parseJSON = genericParseJSON defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True}
+
 instance ToJSON Errors where
-  toEncoding = genericToEncoding defaultOptions { constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True }
+  toEncoding = genericToEncoding defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True}
 
 -- | Authorization Code Grant Error Responses https://tools.ietf.org/html/rfc6749#section-4.1.2.1
 -- Implicit Grant Error Responses https://tools.ietf.org/html/rfc6749#section-4.2.2.1
-data Errors =
-    InvalidRequest
+data Errors
+  = InvalidRequest
   | UnauthorizedClient
   | AccessDenied
   | UnsupportedResponseType
@@ -21,3 +35,21 @@ data Errors =
   | ServerError
   | TemporarilyUnavailable
   deriving (Show, Eq, Generic)
+
+--------------------------------------------------
+
+-- * URLs
+
+--------------------------------------------------
+
+-- | Prepare the authorization URL.  Redirect to this URL
+-- asking for user interactive authentication.
+authorizationUrl :: OAuth2 -> URI
+authorizationUrl oa = over (queryL . queryPairsL) (++ queryParts) (oauth2AuthorizeEndpoint oa)
+  where
+    queryParts =
+      catMaybes
+        [ Just ("client_id", T.encodeUtf8 $ oauth2ClientId oa),
+          Just ("response_type", "code"),
+          fmap (("redirect_uri",) . serializeURIRef') (oauth2RedirectUri oa)
+        ]

--- a/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
@@ -90,7 +90,7 @@ authGetBSInternal ::
 authGetBSInternal authTypes manager token url = do
   let appendToUrl = ClientSecretGet `elem` authTypes
   let appendToHeader = ClientSecretBasic `elem` authTypes
-  let uri = if appendToUrl then (url `appendAccessToken` token) else url
+  let uri = if appendToUrl then url `appendAccessToken` token else url
   let upReq = updateRequestHeaders (if appendToHeader then Just token else Nothing) . setMethod HT.GET
   req <- liftIO $ uriToRequest uri
   authRequest req upReq manager
@@ -173,7 +173,7 @@ authPostBSInternal ::
 authPostBSInternal authTypes manager token url body = do
   let appendToBody = ClientSecretPost `elem` authTypes
   let appendToHeader = ClientSecretBasic `elem` authTypes
-  let reqBody = if appendToBody then (body ++ accessTokenToParam token) else body
+  let reqBody = if appendToBody then body ++ accessTokenToParam token else body
   let upBody = urlEncodedBody reqBody
   let upHeaders = updateRequestHeaders (if appendToHeader then Just token else Nothing) . setMethod HT.POST
   let upReq = upHeaders . upBody

--- a/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
@@ -11,6 +11,7 @@ module Network.OAuth.OAuth2.HttpClient
     authGetBSInternal,
     authPostJSON,
     authPostBS,
+    authPostBS1,
     authPostBS2,
     authPostBS3,
     authPostBSInternal,
@@ -112,7 +113,7 @@ authPostJSON manager t uri pb = do
     Left e -> throwE $ BSL.pack e
 
 -- | Conduct POST request.
---   Inject Access Token to both http header (Authorization) and request body.
+--   Inject Access Token to http header (Authorization)
 authPostBS ::
   -- | HTTP connection manager.
   Manager ->
@@ -121,7 +122,20 @@ authPostBS ::
   PostBody ->
   -- | Response as ByteString
   ExceptT BSL.ByteString IO BSL.ByteString
-authPostBS = authPostBSInternal [ClientSecretPost, ClientSecretBasic]
+authPostBS = authPostBSInternal [ClientSecretBasic]
+
+-- | Conduct POST request.
+--   Inject Access Token to both http header (Authorization) and request body.
+authPostBS1 ::
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  PostBody ->
+  -- | Response as ByteString
+  ExceptT BSL.ByteString IO BSL.ByteString
+authPostBS1 = authPostBSInternal [ClientSecretPost, ClientSecretBasic]
+{-# DEPRECATED authPostBS1 "use authPostBSInternal" #-}
 
 -- | Conduct POST request with access token only in the request body but header.
 authPostBS2 ::

--- a/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
@@ -74,7 +74,7 @@ authGetBS2 ::
   URI ->
   -- | Response as ByteString
   ExceptT BSL.ByteString IO BSL.ByteString
-authGetBS2 = authGetBSInternal [ClientSecretGet]
+authGetBS2 = authGetBSInternal [AuthInRequestQuery]
 {-# DEPRECATED authGetBS2 "use authGetBSInternal" #-}
 
 -- |

--- a/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/HttpClient.hs
@@ -1,177 +1,52 @@
-{-# LANGUAGE ExplicitForAll    #-}
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | A simple http client to request OAuth2 tokens and several utils.
-
-module Network.OAuth.OAuth2.HttpClient (
--- * Token management
-  fetchAccessToken,
-  fetchAccessToken2,
-  refreshAccessToken,
-  refreshAccessToken2,
-  doSimplePostRequest,
--- * AUTH requests
-  authGetJSON,
-  authGetBS,
-  authGetBS2,
-  authPostJSON,
-  authPostBS,
-  authPostBS2,
-  authPostBS3,
-  authRequest
-) where
+module Network.OAuth.OAuth2.HttpClient
+  ( -- * AUTH requests
+    authGetJSON,
+    authGetBS,
+    authGetBS2,
+    authPostJSON,
+    authPostBS,
+    authPostBS2,
+    authPostBS3,
+    authRequest,
+  )
+where
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except
-import qualified Data.Aeson.KeyMap as KeyMap
-import           qualified Data.Aeson.Key as Key
-import           Data.Aeson
-import qualified Data.ByteString.Char8             as BS
-import qualified Data.ByteString.Lazy.Char8        as BSL
-import           Data.Maybe
-import qualified Data.Text.Encoding                as T
-import           Network.HTTP.Conduit
-import qualified Network.HTTP.Types                as HT
-import           Network.HTTP.Types.URI            (parseQuery)
-import           Network.OAuth.OAuth2.Internal
-import qualified Network.OAuth.OAuth2.TokenRequest as TR
-import           URI.ByteString
+import Data.Aeson
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Maybe
+import qualified Data.Text.Encoding as T
+import Lens.Micro
+import Network.HTTP.Conduit
+import qualified Network.HTTP.Types as HT
+import Network.OAuth.OAuth2.Internal
+import URI.ByteString
 
 --------------------------------------------------
--- * Token management
---------------------------------------------------
 
--- | Fetch OAuth2 Token with authenticate in request header.
---
--- OAuth2 spec allows `client_id` and `client_secret` to
--- either be sent in the header (as basic authentication)
--- OR as form/url params.
--- The OAuth server can choose to implement only one, or both.
--- Unfortunately, there is no way for the OAuth client (i.e. this library) to
--- know which method to use. Please take a look at the documentation of the
--- service that you are integrating with and either use `fetchAccessToken` or `fetchAccessToken2`
-fetchAccessToken :: Manager                                   -- ^ HTTP connection manager
-                   -> OAuth2                                  -- ^ OAuth Data
-                   -> ExchangeToken                           -- ^ OAuth2 Code
-                   -> ExceptT (OAuth2Error TR.Errors) IO OAuth2Token -- ^ Access Token
-fetchAccessToken manager oa code = doJSONPostRequest manager oa uri body
-                           where (uri, body) = accessTokenUrl oa code
-
--- | Please read the docs of `fetchAccessToken`.
---
-fetchAccessToken2 :: Manager                                   -- ^ HTTP connection manager
-                   -> OAuth2                                  -- ^ OAuth Data
-                   -> ExchangeToken                           -- ^ OAuth 2 Tokens
-                   -> ExceptT (OAuth2Error TR.Errors) IO OAuth2Token -- ^ Access Token
-fetchAccessToken2 mgr oa code = do
-  let (url, body1) = accessTokenUrl oa code
-  let extraBody = [
-        ("client_id", T.encodeUtf8 $ oauth2ClientId oa),
-        ("client_secret", T.encodeUtf8 $ oauth2ClientSecret oa)
-        ]
-  doJSONPostRequest mgr oa url (extraBody ++ body1)
-
--- | Fetch a new AccessToken with the Refresh Token with authentication in request header.
--- OAuth2 spec allows `client_id` and `client_secret` to
--- either be sent in the header (as basic authentication)
--- OR as form/url params.
--- The OAuth server can choose to implement only one, or both.
--- Unfortunately, there is no way for the OAuth client (i.e. this library) to
--- know which method to use. Please take a look at the documentation of the
--- service that you are integrating with and either use `refreshAccessToken` or `refreshAccessToken2`
-refreshAccessToken :: Manager                         -- ^ HTTP connection manager.
-                     -> OAuth2                       -- ^ OAuth context
-                     -> RefreshToken                 -- ^ refresh token gained after authorization
-                     -> ExceptT (OAuth2Error TR.Errors) IO OAuth2Token
-refreshAccessToken manager oa token = doJSONPostRequest manager oa uri body
-                              where (uri, body) = refreshAccessTokenUrl oa token
-
--- | Please read the docs of `refreshAccessToken`.
---
-refreshAccessToken2 :: Manager                         -- ^ HTTP connection manager.
-                     -> OAuth2                       -- ^ OAuth context
-                     -> RefreshToken                 -- ^ refresh token gained after authorization
-                     -> ExceptT (OAuth2Error TR.Errors) IO OAuth2Token
-refreshAccessToken2 manager oa token = do
-  let (uri, body) = refreshAccessTokenUrl oa token
-  let extraBody = [
-        ("client_id", T.encodeUtf8 $ oauth2ClientId oa),
-        ("client_secret", T.encodeUtf8 $ oauth2ClientSecret oa)
-        ]
-  doJSONPostRequest manager oa uri (extraBody ++ body)
-
--- | Conduct post request and return response as JSON.
-doJSONPostRequest :: (FromJSON err, FromJSON a)
-                  => Manager                             -- ^ HTTP connection manager.
-                  -> OAuth2                              -- ^ OAuth options
-                  -> URI                                 -- ^ The URL
-                  -> PostBody                            -- ^ request body
-                  -> ExceptT (OAuth2Error err) IO a -- ^ Response as JSON
-doJSONPostRequest manager oa uri body = do
-  resp <- doSimplePostRequest manager oa uri body
-  case parseResponseFlexible resp of
-    Right obj -> return obj
-    Left e -> throwE e
-
--- | Conduct post request.
-doSimplePostRequest :: FromJSON err => Manager                 -- ^ HTTP connection manager.
-                       -> OAuth2                               -- ^ OAuth options
-                       -> URI                                  -- ^ URL
-                       -> PostBody                             -- ^ Request body.
-                       -> ExceptT  (OAuth2Error err) IO  BSL.ByteString -- ^ Response as ByteString
-doSimplePostRequest manager oa url body =
-  ExceptT $ fmap handleOAuth2TokenResponse go
-  where
-    addBasicAuth = applyBasicAuth (T.encodeUtf8 $ oauth2ClientId oa) (T.encodeUtf8 $ oauth2ClientSecret oa)
-    go = do
-          req <- uriToRequest url
-          let req' = (addBasicAuth . updateRequestHeaders Nothing) req
-          httpLbs (urlEncodedBody body req') manager
-
--- | Parses a @Response@ to to @OAuth2Result@
-handleOAuth2TokenResponse :: FromJSON err => Response BSL.ByteString -> Either (OAuth2Error err) BSL.ByteString
-handleOAuth2TokenResponse rsp =
-    if HT.statusIsSuccessful (responseStatus rsp)
-        then Right $ responseBody rsp
-        else Left $ parseOAuth2Error (responseBody rsp)
-
--- | Try 'parseResponseJSON', if failed then parses the @OAuth2Result BSL.ByteString@ that contains not JSON but a Query String.
-parseResponseFlexible :: (FromJSON err, FromJSON a)
-                         => BSL.ByteString
-                         -> Either (OAuth2Error err) a
-parseResponseFlexible r = case eitherDecode r of
-                           Left _   -> parseResponseString r
-                           Right x  -> Right x
-
--- | Parses a @OAuth2Result BSL.ByteString@ that contains not JSON but a Query String
-parseResponseString :: (FromJSON err, FromJSON a)
-              => BSL.ByteString
-              -> Either (OAuth2Error err) a
-parseResponseString b = case parseQuery $ BSL.toStrict b of
-                              [] -> Left errorMessage
-                              a -> case fromJSON $ queryToValue a of
-                                    Error _   -> Left errorMessage
-                                    Success x -> Right x
-  where
-    queryToValue = Object . KeyMap.fromList . map paramToPair
-    paramToPair (k, mv) = (Key.fromText $T.decodeUtf8 k, maybe Null (String . T.decodeUtf8) mv)
-    errorMessage = parseOAuth2Error b
-
---------------------------------------------------
 -- * AUTH requests
--- Making request with Access Token injected into header or request body.
+
+-- Making request with Access Token appended to Header, Request body or query string.
 --
 --------------------------------------------------
 
 -- | Conduct an authorized GET request and return response as JSON.
 --   Inject Access Token to Authorization Header.
---
-authGetJSON :: (FromJSON b)
-                 => Manager                 -- ^ HTTP connection manager.
-                 -> AccessToken
-                 -> URI
-                 -> ExceptT BSL.ByteString IO b -- ^ Response as JSON
+authGetJSON ::
+  (FromJSON b) =>
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  -- | Response as JSON
+  ExceptT BSL.ByteString IO b
 authGetJSON manager t uri = do
   resp <- authGetBS manager t uri
   case eitherDecode resp of
@@ -180,36 +55,44 @@ authGetJSON manager t uri = do
 
 -- | Conduct an authorized GET request.
 --   Inject Access Token to Authorization Header.
---
-authGetBS :: Manager                 -- ^ HTTP connection manager.
-             -> AccessToken
-             -> URI
-             -> ExceptT BSL.ByteString IO BSL.ByteString -- ^ Response as ByteString
+authGetBS ::
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  -- | Response as ByteString
+  ExceptT BSL.ByteString IO BSL.ByteString
 authGetBS manager token url = do
   req <- uriToRequest url
   authRequest req upReq manager
-  where upReq = updateRequestHeaders (Just token) . setMethod HT.GET
+  where
+    upReq = updateRequestHeaders (Just token) . setMethod HT.GET
 
 -- | Same to 'authGetBS' but set access token to query parameter rather than header
---
-authGetBS2 :: Manager                -- ^ HTTP connection manager.
-             -> AccessToken
-             -> URI
-             -> ExceptT BSL.ByteString IO BSL.ByteString -- ^ Response as ByteString
+authGetBS2 ::
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  -- | Response as ByteString
+  ExceptT BSL.ByteString IO BSL.ByteString
 authGetBS2 manager token url = do
   req <- liftIO $ uriToRequest (url `appendAccessToken` token)
   authRequest req upReq manager
-  where upReq = updateRequestHeaders Nothing . setMethod HT.GET
+  where
+    upReq = updateRequestHeaders Nothing . setMethod HT.GET
 
 -- | Conduct POST request and return response as JSON.
 --   Inject Access Token to Authorization Header and request body.
---
-authPostJSON :: (FromJSON b)
-                 => Manager                 -- ^ HTTP connection manager.
-                 -> AccessToken
-                 -> URI
-                 -> PostBody
-                 -> ExceptT BSL.ByteString IO b -- ^ Response as JSON
+authPostJSON ::
+  (FromJSON b) =>
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  PostBody ->
+  -- | Response as JSON
+  ExceptT BSL.ByteString IO b
 authPostJSON manager t uri pb = do
   resp <- authPostBS manager t uri pb
   case eitherDecode resp of
@@ -218,64 +101,79 @@ authPostJSON manager t uri pb = do
 
 -- | Conduct POST request.
 --   Inject Access Token to http header (Authorization) and request body.
---
-authPostBS :: Manager                -- ^ HTTP connection manager.
-             -> AccessToken
-             -> URI
-             -> PostBody
-             -> ExceptT BSL.ByteString IO BSL.ByteString -- ^ Response as ByteString
+authPostBS ::
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  PostBody ->
+  -- | Response as ByteString
+  ExceptT BSL.ByteString IO BSL.ByteString
 authPostBS manager token url pb = do
   req <- uriToRequest url
   authRequest req upReq manager
-  where upBody = urlEncodedBody (pb ++ accessTokenToParam token)
-        upHeaders = updateRequestHeaders (Just token) . setMethod HT.POST
-        upReq = upHeaders . upBody
+  where
+    upBody = urlEncodedBody (pb ++ accessTokenToParam token)
+    upHeaders = updateRequestHeaders (Just token) . setMethod HT.POST
+    upReq = upHeaders . upBody
 
 -- | Conduct POST request with access token only in the request body but header.
---
-authPostBS2 :: Manager               -- ^ HTTP connection manager.
-             -> AccessToken
-             -> URI
-             -> PostBody
-             -> ExceptT BSL.ByteString IO BSL.ByteString -- ^ Response as ByteString
+authPostBS2 ::
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  PostBody ->
+  -- | Response as ByteString
+  ExceptT BSL.ByteString IO BSL.ByteString
 authPostBS2 manager token url pb = do
   req <- uriToRequest url
   authRequest req upReq manager
-  where upBody = urlEncodedBody (pb ++ accessTokenToParam token)
-        upHeaders = updateRequestHeaders Nothing . setMethod HT.POST
-        upReq = upHeaders . upBody
+  where
+    upBody = urlEncodedBody (pb ++ accessTokenToParam token)
+    upHeaders = updateRequestHeaders Nothing . setMethod HT.POST
+    upReq = upHeaders . upBody
 
 -- | Conduct POST request with access token only in the header and not in body
-authPostBS3 :: Manager               -- ^ HTTP connection manager.
-             -> AccessToken
-             -> URI
-             -> ExceptT BSL.ByteString IO BSL.ByteString -- ^ Response as ByteString
+authPostBS3 ::
+  -- | HTTP connection manager.
+  Manager ->
+  AccessToken ->
+  URI ->
+  -- | Response as ByteString
+  ExceptT BSL.ByteString IO BSL.ByteString
 authPostBS3 manager token url = do
   req <- uriToRequest url
   authRequest req upReq manager
-  where upBody req = req { requestBody = "null" }
-        upHeaders = updateRequestHeaders (Just token) . setMethod HT.POST
-        upReq = upHeaders . upBody
-
--- |Send an HTTP request including the Authorization header with the specified
---  access token.
---
-authRequest :: Request          -- ^ Request to perform
-               -> (Request -> Request)          -- ^ Modify request before sending
-               -> Manager                       -- ^ HTTP connection manager.
-               -> ExceptT BSL.ByteString IO BSL.ByteString
-authRequest req upReq manage = ExceptT $ handleResponse <$> httpLbs (upReq req) manage
+  where
+    upBody req = req {requestBody = "null"}
+    upHeaders = updateRequestHeaders (Just token) . setMethod HT.POST
+    upReq = upHeaders . upBody
 
 --------------------------------------------------
+
 -- * Utilities
+
 --------------------------------------------------
+
+-- | Send an HTTP request.
+authRequest ::
+  -- | Request to perform
+  Request ->
+  -- | Modify request before sending
+  (Request -> Request) ->
+  -- | HTTP connection manager.
+  Manager ->
+  ExceptT BSL.ByteString IO BSL.ByteString
+authRequest req upReq manage = ExceptT $ handleResponse <$> httpLbs (upReq req) manage
 
 -- | Parses a @Response@ to to @OAuth2Result@
 handleResponse :: Response BSL.ByteString -> Either BSL.ByteString BSL.ByteString
 handleResponse rsp =
-    if HT.statusIsSuccessful (responseStatus rsp)
-        then Right $ responseBody rsp
-        else Left $ responseBody rsp
+  if HT.statusIsSuccessful (responseStatus rsp)
+    then Right $ responseBody rsp
+    else -- TODO: better to surface up entire resp so that client can decide what to do when error happens.
+      Left $ responseBody rsp
 
 -- | Set several header values:
 --   + userAgennt    : `hoauth2`
@@ -283,13 +181,24 @@ handleResponse rsp =
 --   + authorization : 'Bearer' `xxxxx` if 'AccessToken' provided.
 updateRequestHeaders :: Maybe AccessToken -> Request -> Request
 updateRequestHeaders t req =
-  let extras = [ (HT.hUserAgent, "hoauth2")
-               , (HT.hAccept, "application/json") ]
-      bearer = [(HT.hAuthorization, "Bearer " `BS.append` T.encodeUtf8 (atoken (fromJust t))) | isJust t]
-      headers = bearer ++ extras ++ requestHeaders req
-  in
-  req { requestHeaders = headers }
+  let bearer = [(HT.hAuthorization, "Bearer " `BS.append` T.encodeUtf8 (atoken (fromJust t))) | isJust t]
+      headers = bearer ++ defaultRequestHeaders ++ requestHeaders req
+   in req {requestHeaders = headers}
 
 -- | Set the HTTP method to use.
 setMethod :: HT.StdMethod -> Request -> Request
-setMethod m req = req { method = HT.renderStdMethod m }
+setMethod m req = req {method = HT.renderStdMethod m}
+
+-- | For `GET` method API.
+appendAccessToken ::
+  -- | Base URI
+  URIRef a ->
+  -- | Authorized Access Token
+  AccessToken ->
+  -- | Combined Result
+  URIRef a
+appendAccessToken uri t = over (queryL . queryPairsL) (\query -> query ++ accessTokenToParam t) uri
+
+-- | Create 'QueryParams' with given access token value.
+accessTokenToParam :: AccessToken -> [(BS.ByteString, BS.ByteString)]
+accessTokenToParam t = [("access_token", T.encodeUtf8 $ atoken t)]

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -127,6 +127,12 @@ mkDecodeOAuth2Error response err =
     (Just $ pack $ "Error: " <> err <> "\n Original Response:\n" <> show (decodeUtf8 $ BSL.toStrict response))
     Nothing
 
+data ClientAuthenticationMethod =
+  ClientSecretBasic -- ^ Provides in Authorization header
+  | ClientSecretPost -- ^ Provides in request body
+  | ClientSecretGet -- ^ Provides in request query parameter
+  deriving (Eq)
+
 --------------------------------------------------
 
 -- * Types Synonym

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -126,10 +126,10 @@ mkDecodeOAuth2Error response err =
     (Just $ pack $ "Error: " <> err <> "\n Original Response:\n" <> show (decodeUtf8 $ BSL.toStrict response))
     Nothing
 
-data ClientAuthenticationMethod =
-  ClientSecretBasic -- ^ Provides in Authorization header
-  | ClientSecretPost -- ^ Provides in request body
-  | ClientSecretGet -- ^ Provides in request query parameter
+data APIAuthenticationMethod =
+  AuthInRequestHeader -- ^ Provides in Authorization header
+  | AuthInRequestBody -- ^ Provides in request body
+  | AuthInRequestQuery -- ^ Provides in request query parameter
   deriving (Eq)
 
 --------------------------------------------------

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 {-# OPTIONS_HADDOCK -ignore-exports #-}
 
 -- | A simple OAuth2 Haskell binding.  (This is supposed to be
@@ -17,17 +17,18 @@ import Data.Aeson.Types (Parser, explicitParseFieldMaybe)
 import Data.Binary (Binary)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
+import Data.Hashable
 import Data.Maybe
 import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding
+import GHC.Generics
 import Lens.Micro
 import Lens.Micro.Extras
 import Network.HTTP.Conduit as C
 import qualified Network.HTTP.Types as H
+import qualified Network.HTTP.Types as HT
 import URI.ByteString
 import URI.ByteString.Aeson ()
-import Data.Hashable
-import GHC.Generics
 
 --------------------------------------------------
 
@@ -41,17 +42,18 @@ data OAuth2 = OAuth2
     oauth2ClientSecret :: Text,
     oauth2AuthorizeEndpoint :: URIRef Absolute,
     oauth2TokenEndpoint :: URIRef Absolute,
-    oauth2RedirectUri :: Maybe ( URIRef Absolute )
+    oauth2RedirectUri :: Maybe (URIRef Absolute)
   }
   deriving (Show, Eq)
 
 instance Hashable OAuth2 where
-  hashWithSalt salt OAuth2{..} = salt
-    `hashWithSalt` hash oauth2ClientId
-    `hashWithSalt` hash oauth2ClientSecret
-    `hashWithSalt` hash (show oauth2AuthorizeEndpoint)
-    `hashWithSalt` hash (show oauth2TokenEndpoint)
-    `hashWithSalt` hash (show oauth2RedirectUri)
+  hashWithSalt salt OAuth2 {..} =
+    salt
+      `hashWithSalt` hash oauth2ClientId
+      `hashWithSalt` hash oauth2ClientSecret
+      `hashWithSalt` hash (show oauth2AuthorizeEndpoint)
+      `hashWithSalt` hash (show oauth2TokenEndpoint)
+      `hashWithSalt` hash (show oauth2RedirectUri)
 
 newtype AccessToken = AccessToken {atoken :: Text} deriving (Binary, Eq, Show, FromJSON, ToJSON)
 
@@ -138,80 +140,15 @@ type QueryParams = [(BS.ByteString, BS.ByteString)]
 
 --------------------------------------------------
 
--- * URLs
+-- * Utilies
 
 --------------------------------------------------
 
--- | Prepare the authorization URL.  Redirect to this URL
--- asking for user interactive authentication.
-authorizationUrl :: OAuth2 -> URI
-authorizationUrl oa = over (queryL . queryPairsL) (++ queryParts) (oauth2AuthorizeEndpoint oa)
-  where
-    queryParts =
-      catMaybes
-        [ Just ("client_id", encodeUtf8 $ oauth2ClientId oa),
-          Just ("response_type", "code"),
-          fmap (("redirect_uri",) . serializeURIRef') (oauth2RedirectUri oa)
-        ]
-
--- | Prepare the URL and the request body query for fetching an access token.
-accessTokenUrl ::
-  OAuth2 ->
-  -- | access code gained via authorization URL
-  ExchangeToken ->
-  -- | access token request URL plus the request body.
-  (URI, PostBody)
-accessTokenUrl oa code = accessTokenUrl' oa code (Just "authorization_code")
-
--- | Prepare the URL and the request body query for fetching an access token, with
--- optional grant type.
-accessTokenUrl' ::
-  OAuth2 ->
-  -- | access code gained via authorization URL
-  ExchangeToken ->
-  -- | Grant Type
-  Maybe Text ->
-  -- | access token request URL plus the request body.
-  (URI, PostBody)
-accessTokenUrl' oa code gt = (uri, body)
-  where
-    uri = oauth2TokenEndpoint oa
-    body =
-      catMaybes
-        [ Just ("code", encodeUtf8 $ extoken code),
-          ("redirect_uri",) . serializeURIRef' <$> oauth2RedirectUri oa,
-          fmap (("grant_type",) . encodeUtf8) gt
-        ]
-
--- | Using a Refresh Token.  Obtain a new access token by
--- sending a refresh token to the Authorization server.
-refreshAccessTokenUrl ::
-  OAuth2 ->
-  -- | refresh token gained via authorization URL
-  RefreshToken ->
-  -- | refresh token request URL plus the request body.
-  (URI, PostBody)
-refreshAccessTokenUrl oa token = (uri, body)
-  where
-    uri = oauth2TokenEndpoint oa
-    body =
-      [ ("grant_type", "refresh_token"),
-        ("refresh_token", encodeUtf8 $ rtoken token)
-      ]
-
--- | For `GET` method API.
-appendAccessToken ::
-  -- | Base URI
-  URIRef a ->
-  -- | Authorized Access Token
-  AccessToken ->
-  -- | Combined Result
-  URIRef a
-appendAccessToken uri t = over (queryL . queryPairsL) (\query -> query ++ accessTokenToParam t) uri
-
--- | Create 'QueryParams' with given access token value.
-accessTokenToParam :: AccessToken -> [(BS.ByteString, BS.ByteString)]
-accessTokenToParam t = [("access_token", encodeUtf8 $ atoken t)]
+defaultRequestHeaders :: [(HT.HeaderName, BS.ByteString)]
+defaultRequestHeaders =
+  [ (HT.hUserAgent, "hoauth2"),
+    (HT.hAccept, "application/json")
+  ]
 
 appendQueryParams :: [(BS.ByteString, BS.ByteString)] -> URIRef a -> URIRef a
 appendQueryParams params =

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -132,6 +132,10 @@ data APIAuthenticationMethod =
   | AuthInRequestQuery -- ^ Provides in request query parameter
   deriving (Eq)
 
+data ClientAuthenticationMethod =
+  ClientSecretBasic
+  | ClientSecretPost
+  deriving (Eq)
 --------------------------------------------------
 
 -- * Types Synonym

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
 {-# OPTIONS_HADDOCK -ignore-exports #-}
 
 -- | A simple OAuth2 Haskell binding.  (This is supposed to be

--- a/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
@@ -153,7 +153,7 @@ fetchAccessToken manager oa code = doJSONPostRequest manager oa uri body
 
 -- | Fetch OAuth2 Token with authenticate in both request header and body.
 -- Please read the docs of `fetchAccessToken`.
-fetchAccessToken2 ::
+fetchAccessTokenClientCredInBoth ::
   -- | HTTP connection manager
   Manager ->
   -- | OAuth Data
@@ -162,7 +162,7 @@ fetchAccessToken2 ::
   ExchangeToken ->
   -- | Access Token
   ExceptT (OAuth2Error Errors) IO OAuth2Token
-fetchAccessToken2 manager oa code = doJSONPostRequest manager oa uri body
+fetchAccessTokenClientCredInBoth manager oa code = doJSONPostRequest manager oa uri body
   where
     (uri, body) = accessTokenUrlClientCredInBody oa code
 
@@ -190,7 +190,7 @@ refreshAccessToken manager oa token = doJSONPostRequest manager oa uri body
 -- | Fetch a new AccessToken with the Refresh Token with authentication in request header and request body.
 -- Please read the docs of `refreshAccessToken`.
 --
-refreshAccessToken2 ::
+refreshAccessTokenClientCredInBoth ::
   -- | HTTP connection manager.
   Manager ->
   -- | OAuth context
@@ -198,7 +198,7 @@ refreshAccessToken2 ::
   -- | refresh token gained after authorization
   RefreshToken ->
   ExceptT (OAuth2Error Errors) IO OAuth2Token
-refreshAccessToken2 manager oa token = doJSONPostRequest manager oa uri body
+refreshAccessTokenClientCredInBoth manager oa token = doJSONPostRequest manager oa uri body
   where
     (uri, body) = refreshAccessTokenUrlClientCredInBody oa token
 

--- a/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
@@ -1,21 +1,289 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 module Network.OAuth.OAuth2.TokenRequest where
 
-import           Data.Aeson
-import           GHC.Generics
+import Control.Monad.Trans.Except
+import Data.Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Maybe
+import Data.Text (Text)
+import qualified Data.Text.Encoding as T
+import GHC.Generics
+import Network.HTTP.Conduit
+import qualified Network.HTTP.Types as HT
+import Network.HTTP.Types.URI (parseQuery)
+import Network.OAuth.OAuth2.Internal
+import URI.ByteString
+
+--------------------------------------------------
+
+-- * Token Request Errors
+
+--------------------------------------------------
 
 instance FromJSON Errors where
-  parseJSON = genericParseJSON defaultOptions { constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True }
+  parseJSON = genericParseJSON defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True}
+
 instance ToJSON Errors where
-  toEncoding = genericToEncoding defaultOptions { constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True }
+  toEncoding = genericToEncoding defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True}
 
 -- | Token Error Responses https://tools.ietf.org/html/rfc6749#section-5.2
-data Errors =
-    InvalidRequest
+data Errors
+  = InvalidRequest
   | InvalidClient
   | InvalidGrant
   | UnauthorizedClient
   | UnsupportedGrantType
   | InvalidScope
   deriving (Show, Eq, Generic)
+
+--------------------------------------------------
+
+-- * URL
+
+--------------------------------------------------
+
+-- | Prepare the URL and the request body query for fetching an access token.
+accessTokenUrl ::
+  OAuth2 ->
+  -- | access code gained via authorization URL
+  ExchangeToken ->
+  -- | access token request URL plus the request body.
+  (URI, PostBody)
+accessTokenUrl oa code = accessTokenUrl' oa code (Just "authorization_code")
+
+-- | Prepare the URL and the request body query for fetching an access token.
+-- also include client_id and client_secret in the post body
+accessTokenUrlClientCredInBody ::
+  OAuth2 ->
+  -- | access code gained via authorization URL
+  ExchangeToken ->
+  -- | access token request URL plus the request body.
+  (URI, PostBody)
+accessTokenUrlClientCredInBody oa code =
+  let (uri, body) = accessTokenUrl oa code
+      creds =
+        [ ("client_id", T.encodeUtf8 $ oauth2ClientId oa),
+          ("client_secret", T.encodeUtf8 $ oauth2ClientSecret oa)
+        ]
+   in (uri, body ++ creds)
+
+-- | Prepare the URL and the request body query for fetching an access token, with
+-- optional grant type.
+accessTokenUrl' ::
+  OAuth2 ->
+  -- | access code gained via authorization URL
+  ExchangeToken ->
+  -- | Grant Type
+  Maybe Text ->
+  -- | access token request URL plus the request body.
+  (URI, PostBody)
+accessTokenUrl' oa code gt = (uri, body)
+  where
+    uri = oauth2TokenEndpoint oa
+    body =
+      catMaybes
+        [ Just ("code", T.encodeUtf8 $ extoken code),
+          ("redirect_uri",) . serializeURIRef' <$> oauth2RedirectUri oa,
+          fmap (("grant_type",) . T.encodeUtf8) gt
+        ]
+
+-- | Using a Refresh Token.  Obtain a new access token by
+-- sending a refresh token to the Authorization server.
+refreshAccessTokenUrl ::
+  OAuth2 ->
+  -- | refresh token gained via authorization URL
+  RefreshToken ->
+  -- | refresh token request URL plus the request body.
+  (URI, PostBody)
+refreshAccessTokenUrl oa token = (uri, body)
+  where
+    uri = oauth2TokenEndpoint oa
+    body =
+      [ ("grant_type", "refresh_token"),
+        ("refresh_token", T.encodeUtf8 $ rtoken token)
+      ]
+
+refreshAccessTokenUrlClientCredInBody ::
+  OAuth2 ->
+  -- | refresh token gained via authorization URL
+  RefreshToken ->
+  -- | refresh token request URL plus the request body.
+  (URI, PostBody)
+refreshAccessTokenUrlClientCredInBody oa token =
+  let (uri, body) = refreshAccessTokenUrl oa token
+      creds =
+        [ ("client_id", T.encodeUtf8 $ oauth2ClientId oa),
+          ("client_secret", T.encodeUtf8 $ oauth2ClientSecret oa)
+        ]
+   in (uri, body ++ creds)
+
+--------------------------------------------------
+
+-- * Token management
+
+--------------------------------------------------
+
+-- | Fetch OAuth2 Token with authenticate in request header.
+--
+-- OAuth2 spec allows `client_id` and `client_secret` to
+-- either be sent in the header (as basic authentication)
+-- OR as form/url params.
+-- The OAuth server can choose to implement only one, or both.
+-- Unfortunately, there is no way for the OAuth client (i.e. this library) to
+-- know which method to use.
+-- Please take a look at the documentation of the
+-- service that you are integrating with and either use `fetchAccessToken` or `fetchAccessToken2`
+fetchAccessToken ::
+  -- | HTTP connection manager
+  Manager ->
+  -- | OAuth Data
+  OAuth2 ->
+  -- | OAuth2 Code
+  ExchangeToken ->
+  -- | Access Token
+  ExceptT (OAuth2Error Errors) IO OAuth2Token
+fetchAccessToken manager oa code = doJSONPostRequest manager oa uri body
+  where
+    (uri, body) = accessTokenUrl oa code
+
+-- | Fetch OAuth2 Token with authenticate in both request header and body.
+-- Please read the docs of `fetchAccessToken`.
+fetchAccessToken2 ::
+  -- | HTTP connection manager
+  Manager ->
+  -- | OAuth Data
+  OAuth2 ->
+  -- | OAuth 2 Tokens
+  ExchangeToken ->
+  -- | Access Token
+  ExceptT (OAuth2Error Errors) IO OAuth2Token
+fetchAccessToken2 manager oa code = doJSONPostRequest manager oa uri body
+  where
+    (uri, body) = accessTokenUrlClientCredInBody oa code
+
+-- | Fetch a new AccessToken with the Refresh Token with authentication in request header.
+--
+-- OAuth2 spec allows `client_id` and `client_secret` to
+-- either be sent in the header (as basic authentication)
+-- OR as form/url params.
+-- The OAuth server can choose to implement only one, or both.
+-- Unfortunately, there is no way for the OAuth client (i.e. this library) to
+-- know which method to use. Please take a look at the documentation of the
+-- service that you are integrating with and either use `refreshAccessToken` or `refreshAccessToken2`
+refreshAccessToken ::
+  -- | HTTP connection manager.
+  Manager ->
+  -- | OAuth context
+  OAuth2 ->
+  -- | refresh token gained after authorization
+  RefreshToken ->
+  ExceptT (OAuth2Error Errors) IO OAuth2Token
+refreshAccessToken manager oa token = doJSONPostRequest manager oa uri body
+  where
+    (uri, body) = refreshAccessTokenUrl oa token
+
+-- | Fetch a new AccessToken with the Refresh Token with authentication in request header and request body.
+-- Please read the docs of `refreshAccessToken`.
+--
+refreshAccessToken2 ::
+  -- | HTTP connection manager.
+  Manager ->
+  -- | OAuth context
+  OAuth2 ->
+  -- | refresh token gained after authorization
+  RefreshToken ->
+  ExceptT (OAuth2Error Errors) IO OAuth2Token
+refreshAccessToken2 manager oa token = doJSONPostRequest manager oa uri body
+  where
+    (uri, body) = refreshAccessTokenUrlClientCredInBody oa token
+
+--------------------------------------------------
+
+-- * Utilies
+
+--------------------------------------------------
+
+-- | Conduct post request and return response as JSON.
+doJSONPostRequest ::
+  (FromJSON err, FromJSON a) =>
+  -- | HTTP connection manager.
+  Manager ->
+  -- | OAuth options
+  OAuth2 ->
+  -- | The URL
+  URI ->
+  -- | request body
+  PostBody ->
+  -- | Response as JSON
+  ExceptT (OAuth2Error err) IO a
+doJSONPostRequest manager oa uri body = do
+  resp <- doSimplePostRequest manager oa uri body
+  case parseResponseFlexible resp of
+    Right obj -> return obj
+    Left e -> throwE e
+
+-- | Conduct post request.
+doSimplePostRequest ::
+  FromJSON err =>
+  -- | HTTP connection manager.
+  Manager ->
+  -- | OAuth options
+  OAuth2 ->
+  -- | URL
+  URI ->
+  -- | Request body.
+  PostBody ->
+  -- | Response as ByteString
+  ExceptT (OAuth2Error err) IO BSL.ByteString
+doSimplePostRequest manager oa url body =
+  ExceptT $ fmap handleOAuth2TokenResponse go
+  where
+    addBasicAuth = applyBasicAuth (T.encodeUtf8 $ oauth2ClientId oa) (T.encodeUtf8 $ oauth2ClientSecret oa)
+    go = do
+      req <- uriToRequest url
+      let req' = (addBasicAuth . addDefaultRequestHeaders) req
+      httpLbs (urlEncodedBody body req') manager
+
+-- | Parses a @Response@ to to @OAuth2Result@
+handleOAuth2TokenResponse :: FromJSON err => Response BSL.ByteString -> Either (OAuth2Error err) BSL.ByteString
+handleOAuth2TokenResponse rsp =
+  if HT.statusIsSuccessful (responseStatus rsp)
+    then Right $ responseBody rsp
+    else Left $ parseOAuth2Error (responseBody rsp)
+
+-- | Try 'parseResponseJSON', if failed then parses the @OAuth2Result BSL.ByteString@ that contains not JSON but a Query String.
+parseResponseFlexible ::
+  (FromJSON err, FromJSON a) =>
+  BSL.ByteString ->
+  Either (OAuth2Error err) a
+parseResponseFlexible r = case eitherDecode r of
+  Left _ -> parseResponseString r
+  Right x -> Right x
+
+-- | Parses a @OAuth2Result BSL.ByteString@ that contains not JSON but a Query String
+parseResponseString ::
+  (FromJSON err, FromJSON a) =>
+  BSL.ByteString ->
+  Either (OAuth2Error err) a
+parseResponseString b = case parseQuery $ BSL.toStrict b of
+  [] -> Left errorMessage
+  a -> case fromJSON $ queryToValue a of
+    Error _ -> Left errorMessage
+    Success x -> Right x
+  where
+    queryToValue = Object . KeyMap.fromList . map paramToPair
+    paramToPair (k, mv) = (Key.fromText $ T.decodeUtf8 k, maybe Null (String . T.decodeUtf8) mv)
+    errorMessage = parseOAuth2Error b
+
+-- | Set several header values:
+--   + userAgennt    : `hoauth2`
+--   + accept        : `application/json`
+addDefaultRequestHeaders :: Request -> Request
+addDefaultRequestHeaders req =
+  let headers = defaultRequestHeaders ++ requestHeaders req
+   in req {requestHeaders = headers}

--- a/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
@@ -138,6 +138,19 @@ fetchAccessToken manager oa code = doJSONPostRequest manager oa uri body
   where
     (uri, body) = accessTokenUrl oa code
 
+fetchAccessToken2 ::
+  -- | HTTP connection manager
+  Manager ->
+  -- | OAuth Data
+  OAuth2 ->
+  -- | OAuth 2 Tokens
+  ExchangeToken ->
+  -- | Access Token
+  ExceptT (OAuth2Error Errors) IO OAuth2Token
+fetchAccessToken2 = fetchAccessTokenClientCredInBoth
+{-# DEPRECATED fetchAccessToken2 "renamed to fetchAccessTokenClientCredInBoth" #-}
+
+
 -- | Fetch OAuth2 Token with authenticate in both request header and body.
 -- Please read the docs of `fetchAccessToken`.
 fetchAccessTokenClientCredInBoth ::
@@ -173,6 +186,17 @@ refreshAccessToken ::
 refreshAccessToken manager oa token = doJSONPostRequest manager oa uri body
   where
     (uri, body) = refreshAccessTokenUrl oa token
+
+refreshAccessToken2 ::
+  -- | HTTP connection manager.
+  Manager ->
+  -- | OAuth context
+  OAuth2 ->
+  -- | refresh token gained after authorization
+  RefreshToken ->
+  ExceptT (OAuth2Error Errors) IO OAuth2Token
+refreshAccessToken2 = refreshAccessTokenClientCredInBoth
+{-# DEPRECATED refreshAccessToken2 "renamed to fetchAccessTokenClientCredInBoth" #-}
 
 -- | Fetch a new AccessToken with the Refresh Token with authentication in request header and request body.
 -- Please read the docs of `refreshAccessToken`.


### PR DESCRIPTION
- Separates AccessToken related methods from `HttpClient` to `TokenRequest`
- Deprecates `fetchAccessToken2` and `refreshAccessToken2`. Use `xxxInternal` instead.
- Delete `accessTokenUrl'`
- Move `authPostBS` to `authPostBS1`. Copy `authPostBS3` to `authPostBS`
- Deprecates `authGetBS1`, `authPostBS2`, `authPostBS3`, `authPostBS1`

fixes #132