### PR TITLE
Add jwt authentication method for ClientCredential flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ format-cabal:
 	cabal-fmt -i hoauth2-providers-tutorial/hoauth2-providers-tutorial.cabal
 	cabal-fmt -i hoauth2-demo/hoauth2-demo.cabal
 
+format:
+	fourmolu --mode inplace $(git ls-files '*.hs')
+
 ## install ghcid globally: `cabal install ghcid`
 watch-lib:
 	ghcid --command="cabal repl hoauth2" --restart=hoauth2/hoauth2.cabal

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ format-cabal:
 	cabal-fmt -i hoauth2-tutorial/hoauth2-tutorial.cabal
 	cabal-fmt -i hoauth2-providers/hoauth2-providers.cabal
 	cabal-fmt -i hoauth2-providers-tutorial/hoauth2-providers-tutorial.cabal
+	cabal-fmt -i hoauth2-demo/hoauth2-demo.cabal
 
 ## install ghcid globally: `cabal install ghcid`
 watch-lib:

--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,7 @@ index-state: 2022-09-19T22:55:09Z
 --   subdir: plugin
 
 -- Upper bound has been relax in the master branch but not yet released
-source-repository-package
-  type: git
-  location: https://github.com/MichelBoucey/google-oauth2-jwt
-  tag: 823449f74e4d6ec9264d3db9b247bf68edd90062
+-- source-repository-package
+--   type: git
+--   location: https://github.com/MichelBoucey/google-oauth2-jwt
+--   tag: 823449f74e4d6ec9264d3db9b247bf68edd90062

--- a/hoauth2-demo/.gitignore
+++ b/hoauth2-demo/.gitignore
@@ -21,3 +21,4 @@ dev.org
 refs.dot
 .hiedb
 .google-sa.json
+.okta-key.json

--- a/hoauth2-demo/Makefile
+++ b/hoauth2-demo/Makefile
@@ -1,5 +1,5 @@
 ghcid:
-	ghcid --run
+	ghcid --run --warnings
 
 start:
 	cabal run hoauth2-demo

--- a/hoauth2-demo/hoauth2-demo.cabal
+++ b/hoauth2-demo/hoauth2-demo.cabal
@@ -63,6 +63,7 @@ executable hoauth2-demo
     , hoauth2-providers      >=0.1
     , http-conduit           >=2.1    && <2.4
     , http-types             >=0.11   && <0.13
+    , jose-jwt               >=0.9.4  && <0.10
     , microlens              ^>=0.4.0
     , mustache               >=2.2.3  && <2.5.0
     , parsec                 >=3.1.11 && <3.2.0
@@ -74,8 +75,6 @@ executable hoauth2-demo
     , wai                    ^>=3.2
     , wai-middleware-static  >=0.8.1  && <0.10.0
     , warp                   >=3.2    && <3.4
-    , jose-jwt              >= 0.9.4 && < 0.10
-    , google-oauth2-jwt      ^>=0.3
 
   ghc-options:
     -Wall -Wtabs -Wno-unused-do-bind -Wunused-packages -Wpartial-fields

--- a/hoauth2-demo/hoauth2-demo.cabal
+++ b/hoauth2-demo/hoauth2-demo.cabal
@@ -74,6 +74,7 @@ executable hoauth2-demo
     , wai                    ^>=3.2
     , wai-middleware-static  >=0.8.1  && <0.10.0
     , warp                   >=3.2    && <3.4
+    , jose-jwt              >= 0.9.4 && < 0.10
     , google-oauth2-jwt      ^>=0.3
 
   ghc-options:

--- a/hoauth2-demo/src/App.hs
+++ b/hoauth2-demo/src/App.hs
@@ -160,7 +160,7 @@ testClientCredentialGrantTypeH (auth0, okta) = do
   let i = head idpP
   case i of
     "auth0" -> testClientCredentialsGrantType (auth0ClientCredentialsGrantApp auth0)
-    "okta" -> liftIO $ oktaClientCredentialsGrantApp okta >>= testClientCredentialsGrantType
+    "okta" -> liftIO (oktaClientCredentialsGrantApp okta) >>= testClientCredentialsGrantType
     _ -> raise $ "unable to find password grant type flow for idp " <> i
 
 testClientCredentialsGrantType ::

--- a/hoauth2-demo/src/App.hs
+++ b/hoauth2-demo/src/App.hs
@@ -163,7 +163,7 @@ testClientCredentialGrantTypeH (auth0, okta) = do
   let i = head idpP
   case i of
     "auth0" -> testClientCredentialsGrantType (auth0ClientCredentialsGrantApp auth0)
-    "okta" -> testClientCredentialsGrantType (oktaClientCredentialsGrantApp okta)
+    "okta" -> (liftIO $ oktaClientCredentialsGrantApp okta) >>= testClientCredentialsGrantType
     _ -> raise $ "unable to find password grant type flow for idp " <> i
 
 testClientCredentialsGrantType ::
@@ -258,7 +258,7 @@ fetchTokenAndUser c exchangeToken idpData@(DemoAppEnv (DemoAuthorizationApp idpA
         (DemoAppEnv iApp $ sData {loginUser = Just luser, oauth2Token = Just token})
 
 oauth2ErrorToText :: OAuth2Error TR.Errors -> Text
-oauth2ErrorToText e = TL.pack $ "mkTokenRequest - cannot fetch access token. error detail: " ++ show e
+oauth2ErrorToText e = TL.pack $ "conduitTokenRequest - cannot fetch access token. error detail: " ++ show e
 
 tryFetchUser ::
   forall a b.

--- a/hoauth2-demo/src/App.hs
+++ b/hoauth2-demo/src/App.hs
@@ -15,7 +15,6 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
 import Data.Aeson
 import Data.Aeson qualified as Aeson
-import Data.ByteString.Char8 qualified as BS8
 import Data.Maybe
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy qualified as TL
@@ -28,6 +27,7 @@ import Network.OAuth.OAuth2 qualified as OAuth2
 import Network.OAuth.OAuth2.TokenRequest qualified as TR
 import Network.OAuth2.Experiment
 import Network.OAuth2.Provider.Auth0 qualified as IAuth0
+import Network.OAuth2.Provider.Google qualified as IGoogle
 import Network.OAuth2.Provider.Okta qualified as IOkta
 import Network.Wai qualified as WAI
 import Network.Wai.Handler.Warp (run)
@@ -186,7 +186,7 @@ testClientCredentialsGrantType testApp = do
 testJwtBearerGrantTypeH :: ActionM ()
 testJwtBearerGrantTypeH = do
   exceptToActionM $ do
-    GoogleServiceAccountKey {..} <- withExceptT TL.pack (ExceptT $ Aeson.eitherDecodeFileStrict ".google-sa.json")
+    IGoogle.GoogleServiceAccountKey {..} <- withExceptT TL.pack (ExceptT $ Aeson.eitherDecodeFileStrict ".google-sa.json")
     pkey <- liftIO $ GJwt.fromPEMString privateKey
     jwt <-
       withExceptT
@@ -201,7 +201,7 @@ testJwtBearerGrantTypeH = do
               Nothing
               pkey
         )
-    let testApp = googleServiceAccountApp (BS8.pack $ show jwt)
+    let testApp = IGoogle.defaultServiceAccountApp jwt
     mgr <- liftIO $ newManager tlsManagerSettings
     tokenResp <- withExceptT oauth2ErrorToText $ conduitTokenRequest testApp mgr
     user <- tryFetchUser mgr tokenResp testApp

--- a/hoauth2-demo/src/App.hs
+++ b/hoauth2-demo/src/App.hs
@@ -10,7 +10,6 @@
 
 module App (app) where
 
-import Data.Aeson qualified as Aeson
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
@@ -161,7 +160,7 @@ testClientCredentialGrantTypeH (auth0, okta) = do
   let i = head idpP
   case i of
     "auth0" -> testClientCredentialsGrantType (auth0ClientCredentialsGrantApp auth0)
-    "okta" -> (liftIO $ oktaClientCredentialsGrantApp okta) >>= testClientCredentialsGrantType
+    "okta" -> liftIO $ oktaClientCredentialsGrantApp okta >>= testClientCredentialsGrantType
     _ -> raise $ "unable to find password grant type flow for idp " <> i
 
 testClientCredentialsGrantType ::

--- a/hoauth2-demo/src/Idp.hs
+++ b/hoauth2-demo/src/Idp.hs
@@ -111,7 +111,8 @@ oktaClientCredentialsGrantApp i =
     , idpAppJwt = ""
     , idpAppTokenRequestAuthenticationMethod = ClientAssertionJwt
     , idpAppName = "okta-demo-cc-grant-app"
-    , idpAppScope = Set.fromList ["hw-test"]
+    -- , idpAppScope = Set.fromList ["hw-test"]
+    , idpAppScope = Set.fromList ["okta.users.read"]
     , idpAppTokenRequestExtraParams = Map.empty
     , idp = i
     }

--- a/hoauth2-demo/src/Idp.hs
+++ b/hoauth2-demo/src/Idp.hs
@@ -23,6 +23,7 @@ import Data.Maybe
 import Data.Set qualified as Set
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Encoding qualified as TL
 import Env qualified
 import Jose.Jwt
 import Lens.Micro
@@ -40,6 +41,7 @@ import Network.OAuth2.Provider.Okta qualified as IOkta
 import Network.OAuth2.Provider.Slack qualified as ISlack
 import Network.OAuth2.Provider.StackExchange qualified as IStackExchange
 import Network.OAuth2.Provider.Twitter qualified as ITwitter
+import Network.OAuth2.Provider.Utils
 import Network.OAuth2.Provider.Weibo qualified as IWeibo
 import Network.OAuth2.Provider.ZOHO qualified as IZOHO
 import Session
@@ -139,8 +141,7 @@ oktaClientCredentialsGrantApp i = do
           pure
             ClientCredentialsIDPApplication
               { idpAppClientId = clientId
-              , idpAppClientSecret = ""
-              , idpAppJwt = unJwt jwt
+              , idpAppClientSecret = ClientSecret (TL.decodeUtf8 $ bsFromStrict $ unJwt jwt)
               , idpAppTokenRequestAuthenticationMethod = ClientAssertionJwt
               , idpAppName = "okta-demo-cc-grant-jwt-app"
               , -- , idpAppScope = Set.fromList ["hw-test"]
@@ -171,7 +172,6 @@ auth0ClientCredentialsGrantApp i =
   ClientCredentialsIDPApplication
     { idpAppClientId = ""
     , idpAppClientSecret = ""
-    , idpAppJwt = ""
     , idpAppTokenRequestAuthenticationMethod = ClientSecretPost
     , idpAppName = "auth0-demo-cc-grant-app"
     , idpAppScope = Set.fromList ["read:users"]

--- a/hoauth2-demo/src/Idp.hs
+++ b/hoauth2-demo/src/Idp.hs
@@ -140,7 +140,7 @@ oktaClientCredentialsGrantApp i = do
             ClientCredentialsIDPApplication
               { idpAppClientId = clientId
               , idpAppClientSecret = ""
-              , idpAppJwt = (unJwt jwt)
+              , idpAppJwt = unJwt jwt
               , idpAppTokenRequestAuthenticationMethod = ClientAssertionJwt
               , idpAppName = "okta-demo-cc-grant-jwt-app"
               , -- , idpAppScope = Set.fromList ["hw-test"]

--- a/hoauth2-demo/src/Idp.hs
+++ b/hoauth2-demo/src/Idp.hs
@@ -24,7 +24,7 @@ import Data.Set qualified as Set
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy qualified as TL
 import Env qualified
--- import Jose.Jwt
+import Jose.Jwt
 import Lens.Micro
 import Network.OAuth.OAuth2
 import Network.OAuth2.Experiment
@@ -108,13 +108,12 @@ oktaClientCredentialsGrantApp i = do
   keyJsonStr <- BS.readFile ".okta-key.json"
   ejwt <- IOkta.mkOktaClientCredentialAppJwt keyJsonStr clientId i
   case ejwt of
-    Right _ ->
+    Right jwt ->
       pure
         ClientCredentialsIDPApplication
-          { idpAppClientId = ""
+          { idpAppClientId = clientId
           , idpAppClientSecret = ""
-          , idpAppJwt = "RpIjoiZDM0OGViZjAtMzcxZS00MTVkLWJkNzgtN2YzOWY0YTg5OTkxIiwiaWF0IjoxNjY2MjM5NzY5LCJleHAiOjE2NjYyNDAwNjksImlzcyI6IjBvYTltYmtseG4yQWMwb0oyNHg3Iiwic3ViIjoiMG9hOW1ia2x4bjJBYzBvSjI0eDcifQ.eZMSbJ3kA07NZF6vsH38Yvpf9ohCt-nw6FRR6ELWgqHs_OhY5EGmFBkFRi7EnAFue0RwXw7OvvmiANo8Zc42jvLTDV-tgm4O0Wa4sszADBJH9SgqOPQmp4r9D76f0bvF7Fig2L7R-iMp23zAlWZHC_5-Lq9bP-uZnSIL6JhqopKDObmec_JUAxyOl_8-cynSu--XY4lIK_o0igGWPwHW8PMrZQOHF7LuUQFNL5gWHVAFPESeQnuQ3_R_WAzPsaiPbYmPN4hPQNy8lq44sC8sk-PvMcw4Wy45eHsAzJOBosA3-2rdpAvbS3rUHbAJkLKJ73PP-XFlR7apewh5jIe3SQ "
-          -- , idpAppJwt = (unJwt jwt)
+            idpAppJwt = (unJwt jwt)
           , idpAppTokenRequestAuthenticationMethod = ClientAssertionJwt
           , idpAppName = "okta-demo-cc-grant-jwt-app"
           , -- , idpAppScope = Set.fromList ["hw-test"]

--- a/hoauth2-demo/src/Idp.hs
+++ b/hoauth2-demo/src/Idp.hs
@@ -42,6 +42,7 @@ import Network.OAuth2.Provider.StackExchange qualified as IStackExchange
 import Network.OAuth2.Provider.Twitter qualified as ITwitter
 import Network.OAuth2.Provider.Weibo qualified as IWeibo
 import Network.OAuth2.Provider.ZOHO qualified as IZOHO
+import Network.OAuth.OAuth2
 import Session
 import System.Directory
 import Types
@@ -107,6 +108,8 @@ oktaClientCredentialsGrantApp i =
   ClientCredentialsIDPApplication
     { idpAppClientId = ""
     , idpAppClientSecret = ""
+    , idpAppJwt = ""
+    , idpAppTokenRequestAuthenticationMethod = ClientAssertionJwt
     , idpAppName = "okta-demo-cc-grant-app"
     , idpAppScope = Set.fromList ["hw-test"]
     , idpAppTokenRequestExtraParams = Map.empty
@@ -133,6 +136,8 @@ auth0ClientCredentialsGrantApp i =
   ClientCredentialsIDPApplication
     { idpAppClientId = ""
     , idpAppClientSecret = ""
+    , idpAppJwt = ""
+    , idpAppTokenRequestAuthenticationMethod = ClientSecretPost
     , idpAppName = "auth0-demo-cc-grant-app"
     , idpAppScope = Set.fromList ["read:users"]
     , idpAppTokenRequestExtraParams = Map.fromList [("audience ", "https://freizl.auth0.com/api/v2/")]

--- a/hoauth2-demo/src/Idp.hs
+++ b/hoauth2-demo/src/Idp.hs
@@ -10,10 +10,8 @@
 
 module Idp where
 
-import GHC.Generics
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
-import Data.Aeson
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Aeson
 import Data.Aeson.KeyMap qualified as Aeson
@@ -143,23 +141,6 @@ auth0ClientCredentialsGrantApp i =
     , idpAppScope = Set.fromList ["read:users"]
     , idpAppTokenRequestExtraParams = Map.fromList [("audience ", "https://freizl.auth0.com/api/v2/")]
     , idp = i
-    }
-
--- | Service account key (in JSON format) that download from google
-data GoogleServiceAccountKey = GoogleServiceAccountKey
-  { privateKey :: String
-  , clientEmail :: Text
-  } deriving (Generic)
-
-instance FromJSON GoogleServiceAccountKey where
-  parseJSON = genericParseJSON defaultOptions {fieldLabelModifier = camelTo2 '_'}
-
-googleServiceAccountApp :: BS.ByteString -> IdpApplication 'JwtBearer IGoogle.Google
-googleServiceAccountApp jwt =
-  JwtBearerIdpApplication
-    { idpAppName = "foo-google-sa"
-    , idpAppJwt = jwt
-    , idp = IGoogle.defaultGoogleIdp
     }
 
 isSupportPkce :: forall a i. ( 'AuthorizationCode ~ a) => IdpApplication a i -> Bool

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -35,8 +35,7 @@ library
     TypeApplications
     TypeFamilies
 
-  other-modules:
-    Network.OAuth2.Provider.Utils
+  -- other-modules:
 
   exposed-modules:
     Network.OAuth2.Provider.Auth0
@@ -51,6 +50,7 @@ library
     Network.OAuth2.Provider.Slack
     Network.OAuth2.Provider.StackExchange
     Network.OAuth2.Provider.Twitter
+    Network.OAuth2.Provider.Utils
     Network.OAuth2.Provider.Weibo
     Network.OAuth2.Provider.ZOHO
     Network.OIDC.WellKnown

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -68,6 +68,8 @@ library
     , transformers          ^>=0.5
     , unordered-containers  >=0.2.5
     , uri-bytestring        >=0.2.3  && <0.4
+    -- , jose-jwt
+    , google-oauth2-jwt      ^>=0.3
 
   ghc-options:
     -Wall -Wtabs -Wno-unused-do-bind -Wunused-packages -Wpartial-fields

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -68,8 +68,9 @@ library
     , transformers          ^>=0.5
     , unordered-containers  >=0.2.5
     , uri-bytestring        >=0.2.3  && <0.4
-    -- , jose-jwt
+    , jose-jwt              >= 0.9.4 && < 0.10
     , google-oauth2-jwt      ^>=0.3
+    , time
 
   ghc-options:
     -Wall -Wtabs -Wno-unused-do-bind -Wunused-packages -Wpartial-fields

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -45,9 +45,9 @@ library
     Network.OAuth2.Provider.Google
     Network.OAuth2.Provider.Linkedin
     Network.OAuth2.Provider.Okta
-    Network.OAuth2.Provider.Twitter
     Network.OAuth2.Provider.Slack
     Network.OAuth2.Provider.StackExchange
+    Network.OAuth2.Provider.Twitter
     Network.OAuth2.Provider.Weibo
     Network.OAuth2.Provider.ZOHO
     Network.OIDC.WellKnown
@@ -57,21 +57,21 @@ library
     , base                  >=4.5    && <5
     , bytestring            >=0.9    && <0.12
     , containers            ^>=0.6
+    , cryptonite            >=0.30   && <0.31
     , data-default          ^>=0.7
     , directory             ^>=1.3
     , hoauth2               >=2.6
+    , HsOpenSSL             >=0.11   && <0.12
     , http-conduit          >=2.1    && <2.4
     , http-types            >=0.11   && <0.13
+    , jose-jwt              >=0.9.4  && <0.10
     , mtl
     , parsec                >=3.1.11 && <3.2.0
     , text                  >=0.11   && <1.3
+    , time                  >=1.12   && <1.13
     , transformers          ^>=0.5
     , unordered-containers  >=0.2.5
     , uri-bytestring        >=0.2.3  && <0.4
-    , jose-jwt              >= 0.9.4 && < 0.10
-    , google-oauth2-jwt     ^>=0.3
-    , time                  >= 1.12 && < 1.13
-    , base64-bytestring     >= 1.2 && < 1.3
 
   ghc-options:
     -Wall -Wtabs -Wno-unused-do-bind -Wunused-packages -Wpartial-fields

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -69,8 +69,9 @@ library
     , unordered-containers  >=0.2.5
     , uri-bytestring        >=0.2.3  && <0.4
     , jose-jwt              >= 0.9.4 && < 0.10
-    , google-oauth2-jwt      ^>=0.3
-    , time
+    , google-oauth2-jwt     ^>=0.3
+    , time                  >= 1.12 && < 1.13
+    , base64-bytestring     >= 1.2 && < 1.3
 
   ghc-options:
     -Wall -Wtabs -Wno-unused-do-bind -Wunused-packages -Wpartial-fields

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -35,6 +35,9 @@ library
     TypeApplications
     TypeFamilies
 
+  other-modules:
+    Network.OAuth2.Provider.Utils
+
   exposed-modules:
     Network.OAuth2.Provider.Auth0
     Network.OAuth2.Provider.AzureAD

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Google.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Google.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 
 module Network.OAuth2.Provider.Google where
 
@@ -13,7 +14,11 @@ import Crypto.PubKey.RSA.Types
 import Data.Aeson
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor
+#if MIN_VERSION_bytestring(0,11,0)
 import Data.ByteString qualified as BS
+#else
+import Data.ByteString.Lazy qualified as BSL
+#endif
 import Data.Map.Strict qualified as Map
 import Data.Maybe
 import Data.Set qualified as Set
@@ -97,8 +102,13 @@ mkJwt ::
   IO (Either String Jwt)
 mkJwt privateKey iss muser scopes idp = do
   now <- getCurrentTime
+#if MIN_VERSION_bytestring(0,11,0)
+  let bsToStrict = BS.toStrict
+#else
+  let bsToStrict = BSL.toStrict
+#endif
   let payload =
-        BS.toStrict $
+        bsToStrict $
           Aeson.encode $
             Aeson.object $
               [ "iss" .= iss

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Google.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Google.hs
@@ -9,13 +9,13 @@
 
 module Network.OAuth2.Provider.Google where
 
-import Data.Maybe
 import Crypto.PubKey.RSA.Types
 import Data.Aeson
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor
 import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
+import Data.Maybe
 import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Text.Lazy (Text)
@@ -104,11 +104,11 @@ mkJwt privateKey iss muser scopes idp = do
               [ "iss" .= iss
               , "scope" .= T.intercalate " " (map (TL.toStrict . unScope) $ Set.toList scopes)
               , "aud" .= idpTokenEndpoint idp
-              , "exp" .= (tToSeconds $ addUTCTime (secondsToNominalDiffTime 300) now) -- 5 minutes expiration time
-              , "iat" .= (tToSeconds now)
+              , "exp" .= tToSeconds (addUTCTime (secondsToNominalDiffTime 300) now) -- 5 minutes expiration time
+              , "iat" .= tToSeconds now
               ]
                 ++ maybe [] (\a -> ["sub" .= a]) muser
-  first show <$> (rsaEncode RS256 privateKey payload)
+  first show <$> rsaEncode RS256 privateKey payload
   where
     tToSeconds = formatTime defaultTimeLocale "%s"
 
@@ -132,9 +132,9 @@ readPemRsaKey pemStr = do
           , private_d = rsaD k
           , private_p = rsaP k
           , private_q = rsaQ k
-          , private_dP = fromMaybe 0 ( rsaDMP1 k )
-          , private_dQ = fromMaybe 0 ( rsaDMQ1 k )
-          , private_qinv = fromMaybe 0 ( rsaIQMP k )
+          , private_dP = fromMaybe 0 (rsaDMP1 k)
+          , private_dQ = fromMaybe 0 (rsaDMQ1 k)
+          , private_qinv = fromMaybe 0 (rsaIQMP k)
           }
     Nothing -> Left "unable to parse PEM to RSA key"
 
@@ -142,7 +142,7 @@ defaultServiceAccountApp :: Jwt -> IdpApplication 'JwtBearer Google
 defaultServiceAccountApp jwt =
   JwtBearerIdpApplication
     { idpAppName = "google-sa-app"
-    , idpAppJwt = (unJwt jwt)
+    , idpAppJwt = unJwt jwt
     , idp = defaultGoogleIdp
     }
 

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Google.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Google.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE CPP #-}
 
 module Network.OAuth2.Provider.Google where
 
@@ -14,11 +13,6 @@ import Crypto.PubKey.RSA.Types
 import Data.Aeson
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor
-#if MIN_VERSION_bytestring(0,11,0)
-import Data.ByteString qualified as BS
-#else
-import Data.ByteString.Lazy qualified as BSL
-#endif
 import Data.Map.Strict qualified as Map
 import Data.Maybe
 import Data.Set qualified as Set
@@ -32,6 +26,7 @@ import Jose.Jws
 import Jose.Jwt
 import Network.OAuth.OAuth2
 import Network.OAuth2.Experiment
+import Network.OAuth2.Provider.Utils
 import OpenSSL.EVP.PKey (toKeyPair)
 import OpenSSL.PEM (
   PemPasswordSupply (PwNone),
@@ -102,11 +97,6 @@ mkJwt ::
   IO (Either String Jwt)
 mkJwt privateKey iss muser scopes idp = do
   now <- getCurrentTime
-#if MIN_VERSION_bytestring(0,11,0)
-  let bsToStrict = BS.toStrict
-#else
-  let bsToStrict = BSL.toStrict
-#endif
   let payload =
         bsToStrict $
           Aeson.encode $

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
@@ -7,17 +7,26 @@
 
 module Network.OAuth2.Provider.Okta where
 
+import Data.Bifunctor
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString
 import Data.Aeson
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text.Lazy (Text)
+import Data.Time
 import GHC.Generics
 import Network.OAuth.OAuth2
 import Network.OAuth2.Experiment
 import Network.OIDC.WellKnown
 import URI.ByteString.QQ
+import Jose.Jwt
+import Jose.Jws
+import Jose.Jwa
+import Jose.Jwk
 
 data Okta = Okta deriving (Eq, Show)
 
@@ -62,6 +71,32 @@ mkOktaIdp domain = do
         , idpTokenEndpoint = tokenUri
         }
     )
+
+mkOktaClientCredentialAppJwt ::
+  ByteString ->
+  -- | Private key
+  ClientId ->
+  Idp Okta ->
+  IO (Either String Jwt)
+mkOktaClientCredentialAppJwt jsonJwk cid idp =
+   case Aeson.eitherDecodeStrict jsonJwk of
+     Right jwk -> do
+        now <- getCurrentTime
+        let cidStr = unClientId cid
+        let header = Aeson.encode $ Aeson.object
+                        [ "alg" .= RS256
+                        , "typ" .= ( "JWT" :: Text)
+                        ]
+        let body = Aeson.encode $ Aeson.object
+                        [ "iss" .= cidStr
+                        , "sub" .= cidStr
+                        , "aud" .= idpTokenEndpoint idp
+                        , "exp" .= (addUTCTime ( secondsToNominalDiffTime 300 ) now) -- 5 minutes expiration time
+                        , "iat" .= now
+                        ]
+        let payload = header <> "." <> body
+        first show <$> (jwkEncode RS256 jwk (Claims $ BS.toStrict body))
+     Left e -> pure (Left e)
 
 -- https://developer.okta.com/docs/reference/api/oidc/#request-parameters
 -- Okta Org AS doesn't support consent

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
@@ -12,7 +12,6 @@ import Control.Monad.Trans.Except
 import Data.Aeson
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor
-import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text.Lazy (Text)
@@ -24,6 +23,7 @@ import Jose.Jws
 import Jose.Jwt
 import Network.OAuth.OAuth2
 import Network.OAuth2.Experiment
+import Network.OAuth2.Provider.Utils
 import Network.OIDC.WellKnown
 import URI.ByteString.QQ
 
@@ -80,7 +80,7 @@ mkOktaClientCredentialAppJwt jwk cid idp = do
   now <- getCurrentTime
   let cidStr = unClientId cid
   let payload =
-        BS.toStrict $
+        toStrict $
           Aeson.encode $
             Aeson.object
               [ "iss" .= cidStr

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
@@ -86,10 +86,10 @@ mkOktaClientCredentialAppJwt jwk cid idp = do
               [ "iss" .= cidStr
               , "sub" .= cidStr
               , "aud" .= idpTokenEndpoint idp
-              , "exp" .= (tToSeconds $ addUTCTime (secondsToNominalDiffTime 300) now) -- 5 minutes expiration time
-              , "iat" .= (tToSeconds now)
+              , "exp" .= tToSeconds (addUTCTime (secondsToNominalDiffTime 300) now) -- 5 minutes expiration time
+              , "iat" .= tToSeconds now
               ]
-  first show <$> (jwkEncode RS256 jwk $ Claims payload)
+  first show <$> jwkEncode RS256 jwk (Claims payload)
   where
     tToSeconds = formatTime defaultTimeLocale "%s"
 

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
@@ -80,7 +80,7 @@ mkOktaClientCredentialAppJwt jwk cid idp = do
   now <- getCurrentTime
   let cidStr = unClientId cid
   let payload =
-        toStrict $
+        bsToStrict $
           Aeson.encode $
             Aeson.object
               [ "iss" .= cidStr

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Utils.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Utils.hs
@@ -17,5 +17,5 @@ bsFromStrict :: BS.ByteString -> BSL.ByteString
 #if MIN_VERSION_bytestring(0,11,0)
 bsFromStrict = BS.fromStrict
 #else
-bsFromStrict = BS.fromStrict
+bsFromStrict = BSL.fromStrict
 #endif

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Utils.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Utils.hs
@@ -12,3 +12,10 @@ bsToStrict = BS.toStrict
 #else
 bsToStrict = BSL.toStrict
 #endif
+
+bsFromStrict :: BS.ByteString -> BSL.ByteString
+#if MIN_VERSION_bytestring(0,11,0)
+bsFromStrict = BS.fromStrict
+#else
+bsFromStrict = BS.fromStrict
+#endif

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Utils.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Utils.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE CPP #-}
+-- |
+
+module Network.OAuth2.Provider.Utils where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+
+bsToStrict :: BSL.ByteString -> BS.ByteString
+#if MIN_VERSION_bytestring(0,11,0)
+bsToStrict = BS.toStrict
+#else
+bsToStrict = BSL.toStrict
+#endif

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -30,14 +30,12 @@ source-repository head
 library
   hs-source-dirs:     src
   default-language:   Haskell2010
-  autogen-modules:
-    Paths_hoauth2
-
+  autogen-modules:    Paths_hoauth2
   other-modules:
+    Network.OAuth.OAuth2.Internal
     Network.OAuth2.Experiment.Pkce
     Network.OAuth2.Experiment.Types
     Network.OAuth2.Experiment.Utils
-    Network.OAuth.OAuth2.Internal
     Paths_hoauth2
 
   exposed-modules:

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -171,7 +171,7 @@ type QueryParams = [(BS.ByteString, BS.ByteString)]
 
 defaultRequestHeaders :: [(HT.HeaderName, BS.ByteString)]
 defaultRequestHeaders =
-  [ (HT.hUserAgent, "hoauth2-" <> (BS8.pack $ showVersion version))
+  [ (HT.hUserAgent, "hoauth2-" <> BS8.pack (showVersion version))
   , (HT.hAccept, "application/json")
   ]
 

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -149,6 +149,7 @@ mkDecodeOAuth2Error response err =
 data ClientAuthenticationMethod
   = ClientSecretBasic
   | ClientSecretPost
+  | ClientAssertionJwt
   deriving (Eq, Ord)
 
 --------------------------------------------------

--- a/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
@@ -8,13 +8,13 @@ module Network.OAuth.OAuth2.TokenRequest where
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT (..), throwE)
 import Data.Aeson
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.ByteString.Lazy.Char8 as BSL
-import qualified Data.Text.Encoding as T
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.ByteString.Lazy.Char8 qualified as BSL
+import Data.Text.Encoding qualified as T
 import GHC.Generics (Generic)
 import Network.HTTP.Conduit
-import qualified Network.HTTP.Types as HT
+import Network.HTTP.Types qualified as HT
 import Network.HTTP.Types.URI (parseQuery)
 import Network.OAuth.OAuth2.Internal
 import URI.ByteString (URI, serializeURIRef')
@@ -57,9 +57,9 @@ accessTokenUrl ::
 accessTokenUrl oa code =
   let uri = oauth2TokenEndpoint oa
       body =
-        [ ("code", T.encodeUtf8 $ extoken code),
-          ("redirect_uri", serializeURIRef' $ oauth2RedirectUri oa),
-          ("grant_type", "authorization_code")
+        [ ("code", T.encodeUtf8 $ extoken code)
+        , ("redirect_uri", serializeURIRef' $ oauth2RedirectUri oa)
+        , ("grant_type", "authorization_code")
         ]
    in (uri, body)
 
@@ -74,8 +74,8 @@ refreshAccessTokenUrl oa token = (uri, body)
   where
     uri = oauth2TokenEndpoint oa
     body =
-      [ ("grant_type", "refresh_token"),
-        ("refresh_token", T.encodeUtf8 $ rtoken token)
+      [ ("grant_type", "refresh_token")
+      , ("refresh_token", T.encodeUtf8 $ rtoken token)
       ]
 
 --------------------------------------------------
@@ -305,6 +305,6 @@ addDefaultRequestHeaders req =
 -- | Add Credential (client_id, client_secret) to the request post body.
 clientSecretPost :: OAuth2 -> PostBody
 clientSecretPost oa =
-  [ ("client_id", T.encodeUtf8 $ oauth2ClientId oa),
-    ("client_secret", T.encodeUtf8 $ oauth2ClientSecret oa)
+  [ ("client_id", T.encodeUtf8 $ oauth2ClientId oa)
+  , ("client_secret", T.encodeUtf8 $ oauth2ClientSecret oa)
   ]

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -122,6 +122,7 @@ instance IsString Scope where
 newtype ClientId = ClientId {unClientId :: Text}
   deriving (Show, Eq, IsString)
 
+-- | Can be either "Client Secret" or JWT base on client authentication method
 newtype ClientSecret = ClientSecret {unClientSecret :: Text}
   deriving (Eq, IsString)
 

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -761,7 +761,10 @@ instance HasTokenRequest 'ClientCredentials where
       then do
         resp <- ExceptT . liftIO $ do
           req <- uriToRequest (idpTokenEndpoint idp)
-          handleOAuth2TokenResponse <$> httpLbs (urlEncodedBody body (addDefaultRequestHeaders req)) mgr
+          let req' = (urlEncodedBody body (addDefaultRequestHeaders req))
+          print req'
+          print body
+          handleOAuth2TokenResponse <$> httpLbs req'  mgr
         case parseResponseFlexible resp of
           Right obj -> return obj
           Left e -> throwE e

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -49,13 +49,14 @@ import URI.ByteString hiding (UserInfo)
 -------------------------------------------------------------------------------
 
 data GrantTypeFlow
-  = AuthorizationCode
-  | -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.1
-    ResourceOwnerPassword
+  = -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.1
+    AuthorizationCode
   | -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.3
-    ClientCredentials
+    ResourceOwnerPassword
   | -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.4
-    JwtBearer -- \| https://www.rfc-editor.org/rfc/rfc7523.html#section-2.1
+    ClientCredentials
+  | -- | https://www.rfc-editor.org/rfc/rfc7523.html#section-2.1
+    JwtBearer
 
 -------------------------------------------------------------------------------
 

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -555,8 +555,8 @@ data instance IdpApplication 'JwtBearer i = JwtBearerIdpApplication
 
 instance HasTokenRequest 'JwtBearer where
   data TokenRequest 'JwtBearer = JwtBearerTokenRequest
-    { grantType :: GrantTypeValue -- ^ 'GTJwtBearer'
-    , assertion :: BS.ByteString -- ^ The the signed JWT token
+    { grantType :: GrantTypeValue -- \^ 'GTJwtBearer'
+    , assertion :: BS.ByteString -- \^ The the signed JWT token
     }
   type WithExchangeToken 'JwtBearer a = a
 
@@ -757,15 +757,15 @@ instance HasTokenRequest 'ClientCredentials where
             [ idpAppTokenRequestExtraParams
             , toQueryParam tokenReq
             ]
-    case clientAuthenticationMethod tokenReq == ClientAssertionJwt of
-      True -> do
+    if clientAuthenticationMethod tokenReq == ClientAssertionJwt
+      then do
         resp <- ExceptT . liftIO $ do
           req <- uriToRequest (idpTokenEndpoint idp)
           handleOAuth2TokenResponse <$> httpLbs (urlEncodedBody body (addDefaultRequestHeaders req)) mgr
         case parseResponseFlexible resp of
           Right obj -> return obj
           Left e -> throwE e
-      False -> doJSONPostRequest mgr key (idpTokenEndpoint idp) body
+      else doJSONPostRequest mgr key (idpTokenEndpoint idp) body
 
 instance ToQueryParam (TokenRequest 'ClientCredentials) where
   toQueryParam :: TokenRequest 'ClientCredentials -> Map Text Text

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -49,10 +49,13 @@ import URI.ByteString hiding (UserInfo)
 -------------------------------------------------------------------------------
 
 data GrantTypeFlow
-  = AuthorizationCode -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.1
-  | ResourceOwnerPassword -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.3
-  | ClientCredentials -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.4
-  | JwtBearer -- | https://www.rfc-editor.org/rfc/rfc7523.html#section-2.1
+  = AuthorizationCode
+  | -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.1
+    ResourceOwnerPassword
+  | -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.3
+    ClientCredentials
+  | -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+    JwtBearer -- \| https://www.rfc-editor.org/rfc/rfc7523.html#section-2.1
 
 -------------------------------------------------------------------------------
 
@@ -709,9 +712,8 @@ instance ToQueryParam (TokenRequest 'ResourceOwnerPassword) where
 data instance IdpApplication 'ClientCredentials i = ClientCredentialsIDPApplication
   { idpAppClientId :: ClientId
   , idpAppClientSecret :: ClientSecret
-  , idpAppJwt :: BS.ByteString
-  -- ^ FIXME: JWT and client id/secret shall be mutually exclusive base on idpAppTokenRequestAuthenticationMethod
   , idpAppTokenRequestAuthenticationMethod :: ClientAuthenticationMethod
+  -- ^ FIXME: rename to ClientCredential
   , idpAppName :: Text
   , idpAppScope :: Set Scope
   , idpAppTokenRequestExtraParams :: Map Text Text
@@ -741,7 +743,7 @@ instance HasTokenRequest 'ClientCredentials where
       { scope = idpAppScope
       , grantType = GTClientCredentials
       , clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-      , clientAssertion = idpAppJwt
+      , clientAssertion = tlToBS $ unClientSecret idpAppClientSecret
       , clientAuthenticationMethod = idpAppTokenRequestAuthenticationMethod
       }
 

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -761,7 +761,7 @@ instance HasTokenRequest 'ClientCredentials where
       then do
         resp <- ExceptT . liftIO $ do
           req <- uriToRequest (idpTokenEndpoint idp)
-          let req' = (urlEncodedBody body (addDefaultRequestHeaders req))
+          let req' = urlEncodedBody body (addDefaultRequestHeaders req)
           handleOAuth2TokenResponse <$> httpLbs req' mgr
         case parseResponseFlexible resp of
           Right obj -> return obj

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -555,7 +555,7 @@ data instance IdpApplication 'JwtBearer i = JwtBearerIdpApplication
 
 instance HasTokenRequest 'JwtBearer where
   data TokenRequest 'JwtBearer = JwtBearerTokenRequest
-    { grantType :: GrantTypeValue -- | 'GTJwtBearer'
+    { grantType :: GrantTypeValue -- \| 'GTJwtBearer'
     , assertion :: BS.ByteString -- \| The the signed JWT token
     }
   type WithExchangeToken 'JwtBearer a = a
@@ -762,9 +762,7 @@ instance HasTokenRequest 'ClientCredentials where
         resp <- ExceptT . liftIO $ do
           req <- uriToRequest (idpTokenEndpoint idp)
           let req' = (urlEncodedBody body (addDefaultRequestHeaders req))
-          print req'
-          print body
-          handleOAuth2TokenResponse <$> httpLbs req'  mgr
+          handleOAuth2TokenResponse <$> httpLbs req' mgr
         case parseResponseFlexible resp of
           Right obj -> return obj
           Left e -> throwE e

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -48,7 +48,11 @@ import URI.ByteString hiding (UserInfo)
 
 -------------------------------------------------------------------------------
 
-data GrantTypeFlow = AuthorizationCode | ResourceOwnerPassword | ClientCredentials | JwtBearer
+data GrantTypeFlow
+  = AuthorizationCode -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.1
+  | ResourceOwnerPassword -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.3
+  | ClientCredentials -- | https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+  | JwtBearer -- | https://www.rfc-editor.org/rfc/rfc7523.html#section-2.1
 
 -------------------------------------------------------------------------------
 

--- a/hoauth2/src/Network/OAuth2/Experiment/Types.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Types.hs
@@ -555,8 +555,8 @@ data instance IdpApplication 'JwtBearer i = JwtBearerIdpApplication
 
 instance HasTokenRequest 'JwtBearer where
   data TokenRequest 'JwtBearer = JwtBearerTokenRequest
-    { grantType :: GrantTypeValue -- \^ 'GTJwtBearer'
-    , assertion :: BS.ByteString -- \^ The the signed JWT token
+    { grantType :: GrantTypeValue -- | 'GTJwtBearer'
+    , assertion :: BS.ByteString -- \| The the signed JWT token
     }
   type WithExchangeToken 'JwtBearer a = a
 


### PR DESCRIPTION
## Intro

- Fixes #158

## TODOs
- [x] create help method in `hoauth2-provider` (Google, Okta) to build `IdpApplication` (JWT bearner)
- [x] depends on [this module](https://hackage.haskell.org/package/jose-jwt-0.9.4/docs/Jose-Jwt.html)
- [x] can re-purpose `ClientSerect` to be `ClientCredential` ?
- [X] use [readKeyFileFromMemory](https://hackage.haskell.org/package/cryptostore-0.2.2.0/docs/Crypto-Store-PKCS8.html#v:readKeyFileFromMemory) to decode PEM to RSA Private Key
    - dont do it for now but leave as option
    - the only cons using HsOpenSSL (which I'm current using) is it depends on openssl c library, which might be annoying to config it correctly.
- [x] remove `google-oauth2-jwt` dependency by switching to `jose-jwt`.