### PR TITLE
Rename OAuth2Error to TokenRequestError

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,4 @@ jobs:
           cabal build --only-dependencies --enable-tests all
 
       - name: Build
-        run: make build
-
+        run: make rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['9.2.4', '8.10.7']
-        cabal: ['3.6']
+        ghc: ["9.2.4", "8.10.7"]
+        cabal: ["3.6"]
     name: Build hoauth2 on GHC ${{ matrix.ghc }}
 
     steps:
       - uses: actions/checkout@v3
+
       - uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
+
       - uses: actions/cache@v3
         name: Caching
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: Lint
 on:
   pull_request:
     branches:
@@ -11,14 +11,14 @@ jobs:
   hlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: 'Set up HLint'
-      uses: haskell/actions/hlint-setup@v2
-      # with: version: '3.3.6'
+      - name: "Set up HLint"
+        uses: haskell/actions/hlint-setup@v2
 
-    - name: 'Run HLint'
-      uses: haskell/actions/hlint-run@v2
-      with:
-        path: '["hoauth2/src/", "hoauth2-tutorial/src", "hoauth2-tutorial/app", "hoauth2-providers/src", "hoauth2-providers-tutorial/src"]'
-        fail-on: warning
+        # with: version: '3.3.6'
+      - name: "Run HLint"
+        uses: haskell/actions/hlint-run@v2
+        with:
+          path: '["hoauth2/src/", "hoauth2-tutorial/src", "hoauth2-tutorial/app", "hoauth2-providers/src", "hoauth2-providers-tutorial/src"]'
+          fail-on: warning

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   workflow_run:
-    workflows: ["Build"]
+    workflows: [Build]
     branches: [main]
     types:
       - completed
@@ -16,12 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['9.2.4', '8.10.7']
-        cabal: ['3.6']
+        ghc: ["9.2.4", "8.10.7"]
+        cabal: ["3.6"]
     name: Test hoauth2 on GHC ${{ matrix.ghc }}
 
     steps:
       - uses: actions/checkout@v3
+
       - uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_run:
+    workflows: ["Build"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ['9.2.4', '8.10.7']
+        cabal: ['3.6']
+    name: Test hoauth2 on GHC ${{ matrix.ghc }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - uses: actions/cache@v3
+        name: Caching
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-build-ghc-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}
+
+      - name: Install dependencies
+        run: |
+          cabal update
+          cabal build --only-dependencies --enable-tests all
+
+      - name: Test
+        run: cd hoauth2 && cabal test

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,17 @@
 default: build
 
-clean:
+c:
 	cabal clean
 
-build:
+b:
 	cabal build -j --run-tests all
 
 build-ide:
 	cabal build -j --run-tests all --ghc-options="-fwrite-ide-info"
 
-rebuild: clean build
+rb: clean build
 
-hlint-only:
-	hlint .
-
-hlint:
+l:
 	hlint .
 
 hlint-fix:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ b:
 build-ide:
 	cabal build -j --run-tests all --ghc-options="-fwrite-ide-info"
 
-rb: clean build
+rb: c b
 
 l:
 	hlint .

--- a/hoauth2-demo/src/App.hs
+++ b/hoauth2-demo/src/App.hs
@@ -22,7 +22,6 @@ import Network.HTTP.Conduit
 import Network.HTTP.Types
 import Network.OAuth.OAuth2
 import Network.OAuth.OAuth2 qualified as OAuth2
-import Network.OAuth.OAuth2.TokenRequest qualified as TR
 import Network.OAuth2.Experiment
 import Network.OAuth2.Provider.Auth0 qualified as IAuth0
 import Network.OAuth2.Provider.Okta qualified as IOkta
@@ -239,7 +238,7 @@ fetchTokenAndUser c exchangeToken idpData@(DemoAppEnv (DemoAuthorizationApp idpA
         c1
         (DemoAppEnv iApp $ sData {loginUser = Just luser, oauth2Token = Just token})
 
-oauth2ErrorToText :: OAuth2Error TR.Errors -> Text
+oauth2ErrorToText :: TokenRequestError -> Text
 oauth2ErrorToText e = TL.pack $ "conduitTokenRequest - cannot fetch access token. error detail: " ++ show e
 
 tryFetchUser ::

--- a/hoauth2-demo/src/Idp.hs
+++ b/hoauth2-demo/src/Idp.hs
@@ -201,8 +201,10 @@ instance HasDemoLoginUser IZOHO.ZOHO where
 
 instance HasDemoLoginUser IAzureAD.AzureAD where
   toLoginUser :: IAzureAD.AzureADUser -> DemoLoginUser
-  toLoginUser ouser = DemoLoginUser
-    { loginUserName = IAzureAD.email ouser <> " " <> IAzureAD.name ouser}
+  toLoginUser ouser =
+    DemoLoginUser
+      { loginUserName = IAzureAD.email ouser <> " " <> IAzureAD.name ouser
+      }
 
 instance HasDemoLoginUser IWeibo.Weibo where
   toLoginUser :: IWeibo.WeiboUID -> DemoLoginUser

--- a/hoauth2-providers-tutorial/src/HOAuth2ProvidersTutorial.hs
+++ b/hoauth2-providers-tutorial/src/HOAuth2ProvidersTutorial.hs
@@ -20,10 +20,9 @@ import Network.HTTP.Conduit (newManager, tlsManagerSettings)
 import Network.HTTP.Types (status302)
 import Network.OAuth.OAuth2 (
   ExchangeToken (ExchangeToken),
-  OAuth2Error,
   OAuth2Token (accessToken),
+  TokenRequestError,
  )
-import Network.OAuth.OAuth2.TokenRequest qualified as TR
 import Network.OAuth2.Experiment
 import Network.OAuth2.Provider.Auth0 (
   Auth0,
@@ -226,5 +225,5 @@ excepttToActionM e = do
   result <- liftIO $ runExceptT e
   either Scotty.raise pure result
 
-oauth2ErrorToText :: OAuth2Error TR.Errors -> TL.Text
+oauth2ErrorToText :: TokenRequestError -> TL.Text
 oauth2ErrorToText e = TL.pack $ "Unable fetch access token. error detail: " ++ show e

--- a/hoauth2-tutorial/src/HOAuth2Tutorial.hs
+++ b/hoauth2-tutorial/src/HOAuth2Tutorial.hs
@@ -121,14 +121,13 @@ import Network.HTTP.Types (status302)
 import Network.OAuth.OAuth2 (
   ExchangeToken (ExchangeToken),
   OAuth2 (..),
-  OAuth2Error,
   OAuth2Token (accessToken),
+  TokenRequestError,
   appendQueryParams,
   authGetJSON,
   authorizationUrl,
   fetchAccessToken,
  )
-import Network.OAuth.OAuth2.TokenRequest qualified as TR
 import URI.ByteString (URI, serializeURIRef')
 import URI.ByteString.QQ (uri)
 import Web.Scotty (ActionM, scotty)
@@ -284,5 +283,5 @@ excepttToActionM e = do
   result <- liftIO $ runExceptT e
   either Scotty.raise pure result
 
-oauth2ErrorToText :: OAuth2Error TR.Errors -> TL.Text
+oauth2ErrorToText :: TokenRequestError -> TL.Text
 oauth2ErrorToText e = TL.pack $ "Unable fetch access token. error detail: " ++ show e

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -77,3 +77,21 @@ library
   ghc-options:
     -Wall -Wtabs -Wno-unused-do-bind -Wunused-packages -Wpartial-fields
     -Wwarnings-deprecations
+
+test-suite hoauth-tests
+  type:               exitcode-stdio-1.0
+  main-is:            Spec.hs
+  hs-source-dirs:     test
+  ghc-options:        -Wall
+  build-depends:
+    , base     >=4 && <5
+    , aeson                 >=2.0    && <2.2
+    , hoauth2
+    , hspec    >=2 && <3
+
+  other-modules:      Network.OAuth.OAuth2.TokenRequestSpec
+  default-language:   Haskell2010
+  default-extensions:
+    ImportQualifiedPost
+    OverloadedStrings
+  build-tool-depends: hspec-discover:hspec-discover >=2 && <3

--- a/hoauth2/src/Network/OAuth/OAuth2.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2.hs
@@ -14,4 +14,4 @@ module Network.OAuth.OAuth2 (
 import Network.OAuth.OAuth2.AuthorizationRequest hiding (Errors (..))
 import Network.OAuth.OAuth2.HttpClient
 import Network.OAuth.OAuth2.Internal
-import Network.OAuth.OAuth2.TokenRequest hiding (Errors (..))
+import Network.OAuth.OAuth2.TokenRequest

--- a/hoauth2/src/Network/OAuth/OAuth2/AuthorizationRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/AuthorizationRequest.hs
@@ -21,15 +21,12 @@ import URI.ByteString
 --------------------------------------------------
 
 instance FromJSON Errors where
-  parseJSON = genericParseJSON defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True}
-
-instance ToJSON Errors where
-  toEncoding = genericToEncoding defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = True}
+  parseJSON = genericParseJSON defaultOptions {constructorTagModifier = camelTo2 '_'}
 
 -- | Authorization Code Grant Error Responses https://tools.ietf.org/html/rfc6749#section-4.1.2.1
 -- I found hard time to figure a way to test the authorization error flow
--- When anything wrong in @/authorize@ request (redirect to OAuth2 provider),
--- it will end-up at the Provider page hence no way for this library to parse error response.
+-- When anything wrong in @/authorize@ request, it will stuck at the Provider page
+-- hence no way for this library to parse error response.
 -- In other words, @/authorize@ ends up with 4xx or 5xx.
 -- Revisit this whenever find a case OAuth2 provider redirects back to Relying party with errors.
 data Errors

--- a/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Bindings Access Token and Refresh Token part of The OAuth 2.0 Authorization Framework
@@ -34,6 +33,28 @@ data TokenRequestError = TokenRequestError
   }
   deriving (Show, Eq, Generic)
 
+-- | Token Error Responses https://tools.ietf.org/html/rfc6749#section-5.2
+data TokenRequestErrorCode
+  = InvalidRequest
+  | InvalidClient
+  | InvalidGrant
+  | UnauthorizedClient
+  | UnsupportedGrantType
+  | InvalidScope
+  | UnknownErrorCode Text
+  deriving (Show, Eq)
+
+instance FromJSON TokenRequestErrorCode where
+  parseJSON = withText "parseJSON TokenRequestErrorCode" $ \t ->
+    pure $ case t of
+      "invalid_request" -> InvalidRequest
+      "invalid_client" -> InvalidClient
+      "invalid_grant" -> InvalidGrant
+      "unauthorized_client" -> UnauthorizedClient
+      "unsupported_grant_type" -> UnsupportedGrantType
+      "invalid_scope" -> InvalidScope
+      _ -> UnknownErrorCode t
+
 instance FromJSON TokenRequestError where
   parseJSON = genericParseJSON defaultOptions {constructorTagModifier = camelTo2 '_'}
 
@@ -47,28 +68,6 @@ parseTokeRequestError string =
         (UnknownErrorCode "")
         (Just $ T.pack $ "Decode TokenRequestError failed: " <> err <> "\n Original Response:\n" <> show (T.decodeUtf8 $ BSL.toStrict response))
         Nothing
-
-instance FromJSON TokenRequestErrorCode where
-  parseJSON = withText "parseJSON TokenRequestErrorCode" $ \t ->
-    pure $ case t of
-      "invalid_request" -> InvalidRequest
-      "invalid_client" -> InvalidClient
-      "invalid_grant" -> InvalidGrant
-      "unauthorized_client" -> UnauthorizedClient
-      "unsupported_grant_type" -> UnsupportedGrantType
-      "invalid_scope" -> InvalidScope
-      _ -> UnknownErrorCode t
-
--- | Token Error Responses https://tools.ietf.org/html/rfc6749#section-5.2
-data TokenRequestErrorCode
-  = InvalidRequest
-  | InvalidClient
-  | InvalidGrant
-  | UnauthorizedClient
-  | UnsupportedGrantType
-  | InvalidScope
-  | UnknownErrorCode Text
-  deriving (Show, Eq, Generic)
 
 --------------------------------------------------
 

--- a/hoauth2/test/Network/OAuth/OAuth2/TokenRequestSpec.hs
+++ b/hoauth2/test/Network/OAuth/OAuth2/TokenRequestSpec.hs
@@ -1,0 +1,23 @@
+module Network.OAuth.OAuth2.TokenRequestSpec where
+
+import Data.Aeson qualified as Aeson
+import Network.OAuth.OAuth2.TokenRequest
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "parseJSON TokenRequestErrorCode" $ do
+    it "invalid_request" $ do
+      Aeson.eitherDecode "\"invalid_request\"" `shouldBe` Right InvalidRequest
+    it "invalid_client" $ do
+      Aeson.eitherDecode "\"invalid_client\"" `shouldBe` Right InvalidClient
+    it "invalid_grant" $ do
+      Aeson.eitherDecode "\"invalid_grant\"" `shouldBe` Right InvalidGrant
+    it "unauthorized_client" $ do
+      Aeson.eitherDecode "\"unauthorized_client\"" `shouldBe` Right UnauthorizedClient
+    it "unsupported_grant_type" $ do
+      Aeson.eitherDecode "\"unsupported_grant_type\"" `shouldBe` Right UnsupportedGrantType
+    it "invalid_scope" $ do
+      Aeson.eitherDecode "\"invalid_scope\"" `shouldBe` Right InvalidScope
+    it "foo_code" $ do
+      Aeson.eitherDecode "\"foo_code\"" `shouldBe` Right (UnknownErrorCode "foo_code")

--- a/hoauth2/test/Spec.hs
+++ b/hoauth2/test/Spec.hs
@@ -1,0 +1,2 @@
+-- file test/Spec.hs
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
## Description

Authorization Erorrs are not used at all hence doesn't seems beneficial to have data type (`OAuth2Errors`) that could accommodate both. Even it does (I missed use case), prefer being explicit that functions deal with Auth Request returns Auth Error, so as functions that deal with Token Request.
Hence for this PR
- Removed `OAuth2Error` data type
- Create `TokenRequestError` that is dedicated to handle token request errors.


Try to address https://github.com/freizl/hoauth2/issues/84

## TODO

- [x] add unit test for parsing token error response

