### PR TITLE
no need for cryptonite or memory

### DIFF
--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -56,13 +56,13 @@ library
     , binary                ^>=0.8
     , bytestring            >=0.9    && <0.12
     , containers            ^>=0.6
-    , cryptonite            ^>=0.30
+    , cryptohash-sha256
     , data-default          ^>=0.7
     , exceptions            >=0.8.3  && <0.11
     , http-conduit          >=2.1    && <2.4
     , http-types            >=0.11   && <0.13
-    , memory                ^>=0.18
     , microlens             ^>=0.4.0
+    , splitmix              >= 0.0.3
     , text                  ^>=2.0
     , transformers          >=0.6
     , uri-bytestring        >=0.2.3  && <0.4

--- a/hoauth2/src/Network/OAuth2/Experiment/Pkce.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Pkce.hs
@@ -56,9 +56,7 @@ cvMaxLen = 128
 --   ALPHA = %x41-5A / %x61-7A
 --   DIGIT = %x30-39
 getRandomBytes :: Int -> IO BS.ByteString
-getRandomBytes l = do
-  s0 <- SM.initSMGen
-  pure $ unreservedBytes l s0
+getRandomBytes l = unreservedBytes l <$> SM.initSMGen
 
 unreservedBytes :: Int -> SM.SMGen -> BS.ByteString
 unreservedBytes maxBytes s0 = BS.pack $ unfoldr mk (0, s0)


### PR DESCRIPTION
Hi @freizl , I noticed hoauth2 uses cryptonite and memory only for generating uniformly random bits and computing SHA256 hashes. Here I've introduced `splitmix` and `cryptohash-sha256` as dependencies and got rid of `cryptonite` and `memory`, which are very slow to build especially in CI systems.

WDYT?