### PR TITLE
Fetch deviceAuthorizationEndpoint from oidc configuration

### DIFF
--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -27,6 +27,7 @@ library
     ImportQualifiedPost
     OverloadedStrings
     RecordWildCards
+    InstanceSigs
     TypeApplications
     TypeFamilies
 
@@ -68,6 +69,7 @@ library
     , transformers          >=0.4    && <0.7
     , unordered-containers  >=0.2.5  && <0.3
     , uri-bytestring        >=0.2.3  && <0.4
+    , uri-bytestring-aeson  ^>=0.1
 
   ghc-options:
     -Wall -Wtabs -Wno-unused-do-bind -Wunused-packages -Wpartial-fields
@@ -83,6 +85,7 @@ test-suite hoauth-providers-tests
     , base     >=4   && <5
     , hoauth2-providers
     , hspec    >=2   && <3
+    , uri-bytestring        >=0.2.3  && <0.4
 
   other-modules:      Network.OIDC.WellKnownSpec
   default-language:   Haskell2010

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Auth0.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Auth0.hs
@@ -43,16 +43,16 @@ mkAuth0Idp ::
   Text ->
   ExceptT Text m (Idp Auth0)
 mkAuth0Idp domain = do
-  OpenIDConfigurationUris {..} <- fetchWellKnownUris domain
+  OpenIDConfiguration {..} <- fetchWellKnown domain
   pure
     ( Idp
         { idpFetchUserInfo = authGetJSON @(IdpUserInfo Auth0)
         , --  https://auth0.com/docs/api/authentication#user-profile
-          idpUserInfoEndpoint = userinfoUri
+          idpUserInfoEndpoint = userinfoEndpoint
         , -- https://auth0.com/docs/api/authentication#authorization-code-flow
-          idpAuthorizeEndpoint = authorizationUri
+          idpAuthorizeEndpoint = authorizationEndpoint
         , -- https://auth0.com/docs/api/authentication#authorization-code-flow44
-          idpTokenEndpoint = tokenUri
+          idpTokenEndpoint = tokenEndpoint
         }
     )
 

--- a/hoauth2-providers/src/Network/OAuth2/Provider/AzureAD.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/AzureAD.hs
@@ -46,13 +46,13 @@ mkAzureIdp ::
   Text ->
   ExceptT Text m (Idp AzureAD)
 mkAzureIdp domain = do
-  OpenIDConfigurationUris {..} <- fetchWellKnownUris ("login.microsoftonline.com/" <> domain <> "/v2.0")
+  OpenIDConfiguration {..} <- fetchWellKnown ("login.microsoftonline.com/" <> domain <> "/v2.0")
   pure $
     Idp
       { idpFetchUserInfo = authGetJSON @(IdpUserInfo AzureAD)
-      , idpUserInfoEndpoint = userinfoUri
-      , idpAuthorizeEndpoint = authorizationUri
-      , idpTokenEndpoint = tokenUri
+      , idpUserInfoEndpoint = userinfoEndpoint
+      , idpAuthorizeEndpoint = authorizationEndpoint
+      , idpTokenEndpoint = tokenEndpoint
       }
 
 -- | https://learn.microsoft.com/en-us/azure/active-directory/develop/userinfo

--- a/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
+++ b/hoauth2-providers/src/Network/OAuth2/Provider/Okta.hs
@@ -46,13 +46,13 @@ mkOktaIdp ::
   Text ->
   ExceptT Text m (Idp Okta)
 mkOktaIdp domain = do
-  OpenIDConfigurationUris {..} <- fetchWellKnownUris domain
+  OpenIDConfiguration {..} <- fetchWellKnown domain
   pure $
     Idp
       { idpFetchUserInfo = authGetJSON @(IdpUserInfo Okta)
-      , idpUserInfoEndpoint = userinfoUri
-      , idpAuthorizeEndpoint = authorizationUri
-      , idpTokenEndpoint = tokenUri
+      , idpUserInfoEndpoint = userinfoEndpoint
+      , idpAuthorizeEndpoint = authorizationEndpoint
+      , idpTokenEndpoint = tokenEndpoint
       }
 
 mkOktaClientCredentialAppJwt ::

--- a/hoauth2-providers/src/Network/OIDC/WellKnown.hs
+++ b/hoauth2-providers/src/Network/OIDC/WellKnown.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DuplicateRecordFields #-}
 
 module Network.OIDC.WellKnown where
 
@@ -8,45 +7,39 @@ import Control.Monad.Except
 import Control.Monad.IO.Class
 #endif
 import Data.Aeson
+import Data.Aeson.Types
 import Data.Bifunctor
 import Data.ByteString.Lazy (ByteString)
-import Data.ByteString.Lazy qualified as BSL
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TL
 import Network.HTTP.Simple
 import Network.HTTP.Types.Status
 import URI.ByteString
+import URI.ByteString.Aeson ()
 
 -- | Slim OpenID Configuration
 -- TODO: could add more fields to be complete.
 --
 -- See spec <https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata>
 data OpenIDConfiguration = OpenIDConfiguration
-  { issuer :: Text
-  , authorizationEndpoint :: Text
-  , tokenEndpoint :: Text
-  , userinfoEndpoint :: Text
-  , jwksEndpoint :: Text
-  , deviceAuthorizationEndpoint :: Text
+  { issuer :: URI
+  , authorizationEndpoint :: URI
+  , tokenEndpoint :: URI
+  , userinfoEndpoint :: URI
+  , jwksUri :: URI
+  , deviceAuthorizationEndpoint :: URI
   }
   deriving (Show, Eq)
 
-data OpenIDConfigurationUris = OpenIDConfigurationUris
-  { authorizationUri :: URI
-  , tokenUri :: URI
-  , userinfoUri :: URI
-  , jwksUri :: URI
-  , deviceAuthorizationUri :: URI
-  }
-
 instance FromJSON OpenIDConfiguration where
+  parseJSON :: Value -> Parser OpenIDConfiguration
   parseJSON = withObject "parseJSON OpenIDConfiguration" $ \t -> do
     issuer <- t .: "issuer"
     authorizationEndpoint <- t .: "authorization_endpoint"
     tokenEndpoint <- t .: "token_endpoint"
     userinfoEndpoint <- t .: "userinfo_endpoint"
-    jwksEndpoint <- t .: "jwks_uri"
+    jwksUri <- t .: "jwks_uri"
     deviceAuthorizationEndpoint <- t .: "device_authorization_endpoint"
     pure OpenIDConfiguration {..}
 
@@ -62,26 +55,7 @@ fetchWellKnown domain = ExceptT $ do
   let uri = "https://" <> domain <> wellknownUrl
   req <- liftIO $ parseRequest (TL.unpack uri)
   resp <- httpLbs req
-  return (handleWellKnownResponse resp)
-
--- | Similar to 'fetchWellKnown' but only return following endpoints with 'URI' type
---
--- * authorization
--- * token
--- * userinfor
--- * jwks
---
-fetchWellKnownUris :: MonadIO m => TL.Text -> ExceptT Text m OpenIDConfigurationUris
-fetchWellKnownUris domain = do
-  OpenIDConfiguration {..} <- fetchWellKnown domain
-  withExceptT (TL.pack . show) $ do
-    authorizationUri <- ExceptT $ pure (parseURI strictURIParserOptions $ BSL.toStrict $ TL.encodeUtf8 authorizationEndpoint)
-    tokenUri <- ExceptT $ pure (parseURI strictURIParserOptions $ BSL.toStrict $ TL.encodeUtf8 tokenEndpoint)
-    userinfoUri <- ExceptT $ pure (parseURI strictURIParserOptions $ BSL.toStrict $ TL.encodeUtf8 userinfoEndpoint)
-    jwksUri <- ExceptT $ pure (parseURI strictURIParserOptions $ BSL.toStrict $ TL.encodeUtf8 jwksEndpoint)
-    deviceAuthorizationUri <- ExceptT $ pure (parseURI strictURIParserOptions $ BSL.toStrict $ TL.encodeUtf8 deviceAuthorizationEndpoint)
-    pure
-      OpenIDConfigurationUris {..}
+  pure (handleWellKnownResponse resp)
 
 handleWellKnownResponse :: Response ByteString -> Either Text OpenIDConfiguration
 handleWellKnownResponse resp = do

--- a/hoauth2-providers/test/Network/OIDC/WellKnownSpec.hs
+++ b/hoauth2-providers/test/Network/OIDC/WellKnownSpec.hs
@@ -1,26 +1,32 @@
--- |
+{-# LANGUAGE QuasiQuotes #-}
 
 module Network.OIDC.WellKnownSpec where
 
 import Data.Aeson qualified as Aeson
-import Network.OIDC.WellKnown (OpenIDConfiguration(..))
+import Network.OIDC.WellKnown (OpenIDConfiguration (..))
 import Test.Hspec
+import URI.ByteString.QQ
 
 spec :: Spec
 spec = do
   describe "parseJSON OpenIDConfiguration" $ do
     it "parse openidConfiguration response" $ do
-      let response = "{" <>
-                      "\"issuer\": \"https://foo.com\"," <>
-                      "\"authorization_endpoint\": \"https://foo.com/auth\"," <>
-                      "\"token_endpoint\": \"https://foo.com/token\"," <>
-                      "\"userinfo_endpoint\": \"https://foo.com/userinfo\"," <>
-                      "\"jwks_uri\": \"https://foo.com/jwks\"" <>
-                     "}"
-      let expected = OpenIDConfiguration { issuer  = "https://foo.com"
-                                         , authorizationEndpoint = "https://foo.com/auth"
-                                         , tokenEndpoint = "https://foo.com/token"
-                                         , userinfoEndpoint = "https://foo.com/userinfo"
-                                         , jwksUri = "https://foo.com/jwks"
-                                         }
+      let response =
+            "{"
+              <> "\"issuer\": \"https://foo.com\","
+              <> "\"authorization_endpoint\": \"https://foo.com/auth\","
+              <> "\"token_endpoint\": \"https://foo.com/token\","
+              <> "\"userinfo_endpoint\": \"https://foo.com/userinfo\","
+              <> "\"jwks_uri\": \"https://foo.com/jwks\","
+              <> "\"device_authorization_endpoint\": \"https://foo.com/device-code\""
+              <> "}"
+      let expected =
+            OpenIDConfiguration
+              { issuer = [uri|https://foo.com|]
+              , authorizationEndpoint = [uri|https://foo.com/auth|]
+              , tokenEndpoint = [uri|https://foo.com/token|]
+              , userinfoEndpoint = [uri|https://foo.com/userinfo|]
+              , jwksUri = [uri|https://foo.com/jwks|]
+              , deviceAuthorizationEndpoint = [uri|https://foo.com/device-code|]
+              }
       Aeson.eitherDecode response `shouldBe` Right expected

--- a/hoauth2/src/Network/OAuth/OAuth2.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2.hs
@@ -12,9 +12,9 @@ module Network.OAuth.OAuth2 (
   Shall qualified import given the naming collision.
 -}
 import Network.OAuth.OAuth2.AuthorizationRequest hiding (
-  AuthorizationRequestError(..),
-  AuthorizationRequestErrorCode(..),
-  )
+  AuthorizationRequestError (..),
+  AuthorizationRequestErrorCode (..),
+ )
 import Network.OAuth.OAuth2.HttpClient
 import Network.OAuth.OAuth2.Internal
 import Network.OAuth.OAuth2.TokenRequest

--- a/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/TokenRequest.hs
@@ -58,7 +58,7 @@ instance FromJSON TokenRequestError where
     error <- t .: "error"
     errorDescription <- t .:? "error_description"
     errorUri <- t .:? "error_uri"
-    pure TokenRequestError{..}
+    pure TokenRequestError {..}
 
 parseTokeRequestError :: BSL.ByteString -> TokenRequestError
 parseTokeRequestError string =


### PR DESCRIPTION
- Parses `deviceAuthorizationEndpoint` from configuration
- `OpenIDConfigurationUris` is removed hence the `fetchWellKnownUris`
- Fields in `OpenIDConfiguration` now have `URI` type.