### PR TITLE
Refactor network uri

### DIFF
--- a/docs/inbox.org
+++ b/docs/inbox.org
@@ -1,9 +1,9 @@
 #+title: Inbox
 
 * TODO Surface up users :demo_app:
- ~AuthorizationGrantUserStore (MVar (Map.Map IdpName IdpAuthorizationCodeAppSessionData)~
- User AppName would be better since it's already unique.
- Just need to figure out how to match differ UI section
+ - ~AuthorizationGrantUserStore (MVar (Map.Map IdpName IdpAuthorizationCodeAppSessionData)~
+ - User AppName would be better since it's already unique.
+ - Just need to figure out how to match differ UI section
 * TODO Refresh button shall only appear when there is refresh token :demo_app:
 * TODO Add more fields for OpenIDConfiguration or find an existing impl? :oidc:
 * DONE [#A] Rename ~HasTokenRequestClientAuthenticationMethod~ :refactor:
@@ -20,6 +20,7 @@ CLOSED: [2025-03-17 Mon 20:21]
 - 9821fb9f2fc290c490d0bec61832a68d3477dd76
 * TODO Use Log library in demo app :demo_app:
 * TODO Upgrade Scotty :demo_app:
+- hence the way handle errors
 * DONE [#A] [Okta] Unable to parse Client credential token response error :bug:
 CLOSED: [2025-03-17 Mon 13:02]
 :LOGBOOK:
@@ -34,9 +35,9 @@ LOSED: [2025-03-15 Sat 00:00]
 LOGBOOK:
  State "DONE"       from "TODO"       [2025-03-15 Sat 00:00]
 END:
- Can copilot help?
+- Can copilot help? yes!
 
-* TODO [#A] Switch to Network.URI
+* TODO [#A] Switch to Network.URI :hoauth2:
 - network-uri-2.6.4.2
 - it has ~uri~ QQ as well
 - compatible with http conduit

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -104,8 +104,10 @@ test-suite hoauth-tests
     , hoauth2
     , hspec           >=2    && <3
     , uri-bytestring  >=0.3  && <0.5
+    , http-conduit          >=2.1    && <2.4
 
   other-modules:
+    Network.OAuth.OAuth2.InternalSpec
     Network.OAuth.OAuth2.TokenRequestSpec
     Network.OAuth.OAuth2.TokenResponseSpec
 

--- a/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
+++ b/hoauth2/src/Network/OAuth/OAuth2/Internal.hs
@@ -110,7 +110,7 @@ addDefaultRequestHeaders req =
    in req {requestHeaders = headers}
 
 appendQueryParams :: [(BS.ByteString, BS.ByteString)] -> URIRef a -> URIRef a
-appendQueryParams = over (queryL . queryPairsL) (params ++)
+appendQueryParams params = over (queryL . queryPairsL) (params ++)
 
 uriToRequest :: MonadThrow m => URI -> m Request
 uriToRequest = parseRequest . BS8.unpack . serializeURIRef'

--- a/hoauth2/test/Network/OAuth/OAuth2/InternalSpec.hs
+++ b/hoauth2/test/Network/OAuth/OAuth2/InternalSpec.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Network.OAuth.OAuth2.InternalSpec where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.Aeson qualified as Aeson
+import Network.HTTP.Conduit
+import Network.OAuth.OAuth2
+import Test.Hspec
+import URI.ByteString.QQ
+
+spec :: Spec
+spec = do
+  describe "uriToRequest" $ do
+    it "parse http://localhost:3001/abc/foo?scope=openid&prompt=consent" $ do
+      req <- liftIO $ uriToRequest [uri|http://localhost:3001/abc/foo?scope=openid&prompt=consent|]
+      secure req `shouldBe` False
+      path req `shouldBe` "/abc/foo"
+      port req `shouldBe` 3001
+      host req `shouldBe` "localhost"
+      queryString req `shouldBe` "?scope=openid&prompt=consent"
+    it "parse http://localhost:3001/abc/foo" $ do
+      req <- liftIO $ uriToRequest [uri|http://localhost:3001/abc/foo|]
+      secure req `shouldBe` False
+      path req `shouldBe` "/abc/foo"
+      port req `shouldBe` 3001
+      host req `shouldBe` "localhost"
+      queryString req `shouldBe` ""
+    it "parse http://localhost:3001/" $ do
+      req <- liftIO $ uriToRequest [uri|http://localhost:3001/|]
+      secure req `shouldBe` False
+      path req `shouldBe` "/"
+      port req `shouldBe` 3001
+      host req `shouldBe` "localhost"
+      queryString req `shouldBe` ""
+    it "parse https://test.auth0.com/authorize" $ do
+      req <- liftIO $ uriToRequest [uri|https://test.auth0.com/authorize|]
+      secure req `shouldBe` True
+      path req `shouldBe` "/authorize"
+      port req `shouldBe` 443
+      host req `shouldBe` "test.auth0.com"
+      queryString req `shouldBe` ""

--- a/hoauth2/test/Network/OAuth/OAuth2/InternalSpec.hs
+++ b/hoauth2/test/Network/OAuth/OAuth2/InternalSpec.hs
@@ -39,3 +39,32 @@ spec = do
       port req `shouldBe` 443
       host req `shouldBe` "test.auth0.com"
       queryString req `shouldBe` ""
+    it "parse URL with multiple query parameters" $ do
+      req <- liftIO $ uriToRequest [uri|https://api.example.com/oauth2/auth?client_id=123&scope=read,write&state=xyz|]
+      secure req `shouldBe` True
+      path req `shouldBe` "/oauth2/auth"
+      port req `shouldBe` 443
+      host req `shouldBe` "api.example.com"
+      queryString req `shouldBe` "?client_id=123&scope=read%2Cwrite&state=xyz"
+    it "parse URL with special characters in path" $ do
+      req <- liftIO $ uriToRequest [uri|https://api.example.com/oauth2/user+info/profile%20data|]
+      secure req `shouldBe` True
+      -- https://github.com/Soostone/uri-bytestring/issues/55, encode + to space
+      path req `shouldBe` "/oauth2/user%20info/profile%20data"
+      port req `shouldBe` 443
+      host req `shouldBe` "api.example.com"
+      queryString req `shouldBe` ""
+    it "parse URL with fragments (which should be ignored)" $ do
+      req <- liftIO $ uriToRequest [uri|https://api.example.com/callback#access_token=xyz|]
+      secure req `shouldBe` True
+      path req `shouldBe` "/callback"
+      port req `shouldBe` 443
+      host req `shouldBe` "api.example.com"
+      queryString req `shouldBe` ""
+    it "parse URL with non-standard HTTPS port" $ do
+      req <- liftIO $ uriToRequest [uri|https://api.example.com:8443/oauth/token|]
+      secure req `shouldBe` True
+      path req `shouldBe` "/oauth/token"
+      port req `shouldBe` 8443
+      host req `shouldBe` "api.example.com"
+      queryString req `shouldBe` ""

--- a/hoauth2/test/Network/OAuth/OAuth2/InternalSpec.hs
+++ b/hoauth2/test/Network/OAuth/OAuth2/InternalSpec.hs
@@ -3,7 +3,6 @@
 module Network.OAuth.OAuth2.InternalSpec where
 
 import Control.Monad.IO.Class (MonadIO (..))
-import Data.Aeson qualified as Aeson
 import Network.HTTP.Conduit
 import Network.OAuth.OAuth2
 import Test.Hspec
@@ -12,13 +11,13 @@ import URI.ByteString.QQ
 spec :: Spec
 spec = do
   describe "uriToRequest" $ do
-    it "parse http://localhost:3001/abc/foo?scope=openid&prompt=consent" $ do
-      req <- liftIO $ uriToRequest [uri|http://localhost:3001/abc/foo?scope=openid&prompt=consent|]
+    it "parse http://localhost:3001/abc/foo?scope=openid&redirect_uri=http://localhost:3001/callback" $ do
+      req <- liftIO $ uriToRequest [uri|http://localhost:3001/abc/foo?scope=openid&&redirect_uri=http://localhost:3001/callback|]
       secure req `shouldBe` False
       path req `shouldBe` "/abc/foo"
       port req `shouldBe` 3001
       host req `shouldBe` "localhost"
-      queryString req `shouldBe` "?scope=openid&prompt=consent"
+      queryString req `shouldBe` "?scope=openid&redirect_uri=http%3A%2F%2Flocalhost%3A3001%2Fcallback"
     it "parse http://localhost:3001/abc/foo" $ do
       req <- liftIO $ uriToRequest [uri|http://localhost:3001/abc/foo|]
       secure req `shouldBe` False


### PR DESCRIPTION
- Simplify the impl of `uriToRequest` by using `parseRequest` and reduce the footprint of lens and usage on ByteString.URI. Set path to deprecate usage on ByteString.URI.
- Remove `requestToUri`. Not sure how/why it's useful. Encourage to use https://hackage.haskell.org/package/http-client-0.7.18/docs/Network-HTTP-Client.html#v:getUri instead.
- Add unit tests on `uriToRequest`