### PR TITLE
Allow microlens 0.5

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages: */*.cabal
-index-state: 2024-11-19T03:51:16Z
+index-state: 2025-10-04T19:51:13Z
 
 -- TODO: doesn't seem work unless add to ~/.cabal/config
 extra-include-dirs: /opt/homebrew/opt/openssl@3/include

--- a/hoauth2-demo/hoauth2-demo.cabal
+++ b/hoauth2-demo/hoauth2-demo.cabal
@@ -78,7 +78,7 @@ executable hoauth2-demo
     , scotty                 >=0.10.0 && <0.13
     , text                   >=2.0    && <2.3
     , transformers           >=0.4    && <0.7
-    , uri-bytestring         >=0.3    && <0.5
+    , uri-bytestring         >=0.4    && <0.5
     , wai                    ^>=3.2
     , wai-middleware-static  >=0.8.1  && <0.10.0
     , warp                   >=3.2    && <3.4

--- a/hoauth2-providers-tutorial/hoauth2-providers-tutorial.cabal
+++ b/hoauth2-providers-tutorial/hoauth2-providers-tutorial.cabal
@@ -26,7 +26,7 @@ library
     , scotty             >=0.10.0 && <0.13
     , text               >=2.0    && <2.3
     , transformers       >=0.4    && <0.7
-    , uri-bytestring     >=0.3    && <0.5
+    , uri-bytestring     >=0.4    && <0.5
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -73,7 +73,7 @@ library
     , text                  >=2.0  && <2.3
     , time                  >=1.12 && <1.13
     , transformers          >=0.4  && <0.7
-    , uri-bytestring        >=0.3  && <0.5
+    , uri-bytestring        >=0.4  && <0.5
     , uri-bytestring-aeson  ^>=0.1
 
   ghc-options:
@@ -94,7 +94,7 @@ test-suite hoauth-providers-tests
     , base               >=4.11 && <5
     , hoauth2-providers
     , hspec              >=2    && <3
-    , uri-bytestring     >=0.3  && <0.5
+    , uri-bytestring     >=0.4  && <0.5
 
   other-modules:      Network.OIDC.WellKnownSpec
   default-language:   Haskell2010

--- a/hoauth2-tutorial/hoauth2-tutorial.cabal
+++ b/hoauth2-tutorial/hoauth2-tutorial.cabal
@@ -32,7 +32,7 @@ common common
     , scotty          >=0.10 && <0.13
     , text            >=2.0  && <2.3
     , transformers    >=0.4  && <0.7
-    , uri-bytestring  >=0.3  && <0.5
+    , uri-bytestring  >=0.4  && <0.5
 
   default-language: Haskell2010
   ghc-options:

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -85,7 +85,7 @@ library
     , microlens             >=0.4 && <0.6
     , text                  >=2.0    && <2.3
     , transformers          >=0.4    && <0.7
-    , uri-bytestring        >=0.3    && <0.5
+    , uri-bytestring        >=0.4    && <0.5
     , uri-bytestring-aeson  ^>=0.1
 
   ghc-options:
@@ -103,7 +103,7 @@ test-suite hoauth-tests
     , binary          >=0.8  && <0.11
     , hoauth2
     , hspec           >=2    && <3
-    , uri-bytestring  >=0.3  && <0.5
+    , uri-bytestring  >=0.4  && <0.5
     , http-conduit          >=2.1    && <2.4
 
   other-modules:

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -82,7 +82,7 @@ library
     , http-conduit          >=2.1    && <2.4
     , http-types            >=0.11   && <0.13
     , memory                ^>=0.18
-    , microlens             ^>=0.4.0
+    , microlens             >=0.4 && <0.6
     , text                  >=2.0    && <2.3
     , transformers          >=0.4    && <0.7
     , uri-bytestring        >=0.3    && <0.5

--- a/hoauth2/test/Network/OAuth2/InternalSpec.hs
+++ b/hoauth2/test/Network/OAuth2/InternalSpec.hs
@@ -49,8 +49,7 @@ spec = do
     it "parse URL with special characters in path" $ do
       req <- liftIO $ uriToRequest [uri|https://api.example.com/oauth2/user+info/profile%20data|]
       secure req `shouldBe` True
-      -- https://github.com/Soostone/uri-bytestring/issues/55, encode + to space
-      path req `shouldBe` "/oauth2/user%20info/profile%20data"
+      path req `shouldBe` "/oauth2/user+info/profile%20data"
       port req `shouldBe` 443
       host req `shouldBe` "api.example.com"
       queryString req `shouldBe` ""


### PR DESCRIPTION
Relax microlens upper bound to <0.6 so microlens-0.5 is allowed.\n\nChanges:\n- hoauth2/hoauth2.cabal: microlens >=0.4 && <0.6\n- cabal.project: update index-state to 2025-10-04T19:51:13Z for local verification\n\nContext: commercialhaskell/stackage#7851