### PR TITLE
Relax crypton bounds and bump release versions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages: */*.cabal
-index-state: 2025-10-04T19:51:13Z
+index-state: 2026-03-16T01:35:53Z
 
 -- TODO: Doesn't seem to work unless added to ~/.cabal/config
 extra-include-dirs: /opt/homebrew/opt/openssl@3/include

--- a/cabal.project
+++ b/cabal.project
@@ -17,3 +17,9 @@ extra-lib-dirs: /opt/homebrew/opt/openssl@3/lib
 --   type: git
 --   location: https://github.com/MichelBoucey/google-oauth2-jwt
 --   tag: 823449f74e4d6ec9264d3db9b247bf68edd90062
+
+-- `crypton-1.1.x` support depends on an unreleased jose-jwt fix.
+source-repository-package
+  type: git
+  location: https://github.com/tekul/jose-jwt.git
+  tag: f93bd9436d798eb81618fa0f699f677194efcf8c

--- a/hoauth2-demo/hoauth2-demo.cabal
+++ b/hoauth2-demo/hoauth2-demo.cabal
@@ -71,7 +71,7 @@ executable hoauth2-demo
     , hoauth2-providers      >=0.3    && <0.10
     , http-conduit           >=2.1    && <2.4
     , http-types             >=0.11   && <0.13
-    , jose-jwt               >=0.10   && <0.11
+    , jose-jwt               >=0.10   && <0.12
     , mustache               >=2.2.3  && <2.5.0
     , parsec                 >=3.1.11 && <3.2.0
     , pretty-simple          >=4.1    && <4.2

--- a/hoauth2-providers/CHANGELOG.md
+++ b/hoauth2-providers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # hoauth2-provider Changelog
 
+## 0.9.1 (2026-03-15)
+
+- Relax `crypton` upper bound to support `crypton-1.1.x`.
+
 ## 0.9.0 (2025-10-05)
 
 - Add Linear provider

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -63,7 +63,7 @@ library
     , base                  >=4.11 && <5
     , bytestring            >=0.9  && <0.13
     , containers            >=0.6  && <0.9
-    , crypton               >=0.32 && <1.1
+    , crypton               >=0.32 && <1.2
     , hoauth2               >=2.9  && <2.16
     , HsOpenSSL             >=0.11 && <0.12
     , http-conduit          >=2.1  && <2.4

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hoauth2-providers
-version:            0.9.0
+version:            0.9.1
 synopsis:           OAuth2 identity providers
 description:        A collection of well-known OAuth2 identity providers
 homepage:           https://github.com/freizl/hoauth2

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -68,7 +68,7 @@ library
     , HsOpenSSL             >=0.11 && <0.12
     , http-conduit          >=2.1  && <2.4
     , http-types            >=0.11 && <0.13
-    , jose-jwt              >=0.10 && <0.11
+    , jose-jwt              >=0.10 && <0.12
     , mtl                   >=2.0  && <2.4
     , text                  >=2.0  && <2.3
     , time                  >=1.12 && <1.13

--- a/hoauth2/CHANGELOG.md
+++ b/hoauth2/CHANGELOG.md
@@ -1,5 +1,8 @@
 # hoauth2 Changelog
 
+## 2.15.1 (2026-03-15)
+- Relax `crypton` upper bound to support `crypton-1.1.x` for Stackage/Hackage builds.
+
 ## 2.15.0 (2025-10-05)
 - Breaking changes
   - Type and class renames

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -76,7 +76,7 @@ library
     , binary-instances      >=1.0    && <1.1
     , bytestring            >=0.9    && <0.13
     , containers            >=0.6    && <0.9
-    , crypton               >=0.32   && <1.1
+    , crypton               >=0.32   && <1.2
     , data-default          ^>=0.8
     , exceptions            >=0.8.3  && <0.11
     , http-conduit          >=2.1    && <2.4

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 name:               hoauth2
 
 -- http://wiki.haskell.org/Package_versioning_policy
-version:            2.15.0
+version:            2.15.1
 synopsis:           Haskell OAuth2 authentication client
 description:
   This package provides Haskell bindings for the OAuth2 Authorization Framework and Bearer Token Usage.

--- a/hoauth2/src/Network/OAuth2/Experiment/Pkce.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Pkce.hs
@@ -43,7 +43,7 @@ mkPkceParam = do
       }
 
 encodeCodeVerifier :: BS.ByteString -> Text
-encodeCodeVerifier = B64.extractBase64 . B64.encodeBase64Unpadded . BS.pack . ByteArray.unpack . hashSHA256
+encodeCodeVerifier = B64.extractBase64 . B64.encodeBase64Unpadded . hashSHA256
 
 genCodeVerifier :: MonadIO m => m BS.ByteString
 genCodeVerifier = liftIO $ getBytesInternal BS.empty
@@ -64,8 +64,10 @@ getBytesInternal ba
       let bsUnreserved = ba `BS.append` BS.filter isUnreversed bs
       getBytesInternal bsUnreserved
 
-hashSHA256 :: BS.ByteString -> H.Digest H.SHA256
-hashSHA256 = H.hash
+hashSHA256 :: BS.ByteString -> BS.ByteString
+hashSHA256 bs =
+  case H.hash bs of
+    H.Digest digest -> ByteArray.convert digest
 
 isUnreversed :: Word8 -> Bool
 isUnreversed w = w `BS.elem` unreverseBS


### PR DESCRIPTION
## Summary
- relax `crypton` upper bounds in `hoauth2` and `hoauth2-providers` to allow `1.1.x`
- update `cabal.project` `index-state` to a current Hackage state
- bump package versions to `hoauth2-2.15.1` and `hoauth2-providers-0.9.1`
- follow up from the revert on `main`; this is the actual fix on a feature branch

## Context
Stackage comment: https://github.com/commercialhaskell/stackage/issues/7929#issuecomment-4016051963

That comment reports `hoauth2-2.15.0` as out of bounds for `crypton-1.1.0` because the package currently required `crypton <1.1`.

## Validation
- `cabal update`
- `cabal build hoauth2 hoauth2-providers --dry-run`
