### PR TITLE
[codex] Relax containers upper bounds

### DIFF
--- a/hoauth2-demo/hoauth2-demo.cabal
+++ b/hoauth2-demo/hoauth2-demo.cabal
@@ -64,7 +64,7 @@ executable hoauth2-demo
     , aeson                  >=2.0    && <2.3
     , base                   >=4.11   && <5
     , bytestring             >=0.9    && <0.13
-    , containers             >=0.6    && <0.8
+    , containers             >=0.6    && <0.9
     , data-default           ^>=0.8
     , directory              ^>=1.3
     , hoauth2                >=2.9    && <2.16

--- a/hoauth2-providers-tutorial/hoauth2-providers-tutorial.cabal
+++ b/hoauth2-providers-tutorial/hoauth2-providers-tutorial.cabal
@@ -18,7 +18,7 @@ library
   build-depends:
     , base               >=4.11   && <5
     , bytestring         >=0.9    && <0.13
-    , containers         >=0.6    && <0.8
+    , containers         >=0.6    && <0.9
     , hoauth2            >=2.9    && <2.16
     , hoauth2-providers  >=0.3    && <0.10
     , http-conduit       >=2.1    && <2.4

--- a/hoauth2-providers/hoauth2-providers.cabal
+++ b/hoauth2-providers/hoauth2-providers.cabal
@@ -62,7 +62,7 @@ library
     , aeson                 >=2.0  && <2.3
     , base                  >=4.11 && <5
     , bytestring            >=0.9  && <0.13
-    , containers            ^>=0.6
+    , containers            >=0.6  && <0.9
     , crypton               >=0.32 && <1.1
     , hoauth2               >=2.9  && <2.16
     , HsOpenSSL             >=0.11 && <0.12

--- a/hoauth2-tutorial/hoauth2-tutorial.cabal
+++ b/hoauth2-tutorial/hoauth2-tutorial.cabal
@@ -46,4 +46,4 @@ executable hoauth2-tutorial
 executable hoauth2-experiment-tutorial
   import:        common
   main-is:       HOAuth2ExperimentTutorial.hs
-  build-depends: containers >=0.6 && <0.8
+  build-depends: containers >=0.6 && <0.9

--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -75,7 +75,7 @@ library
     , binary                >=0.8    && <0.11
     , binary-instances      >=1.0    && <1.1
     , bytestring            >=0.9    && <0.13
-    , containers            >=0.6    && <0.8
+    , containers            >=0.6    && <0.9
     , crypton               >=0.32   && <1.1
     , data-default          ^>=0.8
     , exceptions            >=0.8.3  && <0.11


### PR DESCRIPTION
## Summary
- relax the `containers` upper bound to `<0.9` across the local packages in this repo
- normalize `hoauth2-providers` from `^>=0.6` to an explicit range so `containers-0.8` is accepted

## Why
Stackage issue `commercialhaskell/stackage#7916` flags `hoauth2-2.15.0` as out of bounds for `containers-0.8`. The repo still had multiple package manifests excluding that release.

## Impact
This allows the `hoauth2` packages in this repo to build against `containers-0.8` without changing code behavior.

## Validation
- `cabal build all --dry-run`
