### PR TITLE
Pkce: fix up hashSHA256 to work with ram

### DIFF
--- a/hoauth2/hoauth2.cabal
+++ b/hoauth2/hoauth2.cabal
@@ -81,7 +81,7 @@ library
     , exceptions            >=0.8.3  && <0.11
     , http-conduit          >=2.1    && <2.4
     , http-types            >=0.11   && <0.13
-    , memory                ^>=0.18
+    , ram
     , microlens             >=0.4 && <0.6
     , text                  >=2.0    && <2.3
     , transformers          >=0.4    && <0.7

--- a/hoauth2/src/Network/OAuth2/Experiment/Pkce.hs
+++ b/hoauth2/src/Network/OAuth2/Experiment/Pkce.hs
@@ -66,8 +66,7 @@ getBytesInternal ba
 
 hashSHA256 :: BS.ByteString -> BS.ByteString
 hashSHA256 bs =
-  case H.hash bs of
-    H.Digest digest -> ByteArray.convert digest
+  ByteArray.convert (H.hash bs :: H.Digest H.SHA256)
 
 isUnreversed :: Word8 -> Bool
 isUnreversed w = w `BS.elem` unreverseBS


### PR DESCRIPTION
This compiles with stackage nightly at least

https://github.com/commercialhaskell/stackage/issues/7929

Untested so please review the `hashSHA256` changes, but `ram` is needed with crypton 1.1